### PR TITLE
Reduce allocations in the formatter

### DIFF
--- a/src/Analyzers/CSharp/CodeFixes/UseConditionalExpression/MultiLineConditionalExpressionFormattingRule.cs
+++ b/src/Analyzers/CSharp/CodeFixes/UseConditionalExpression/MultiLineConditionalExpressionFormattingRule.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseConditionalExpression
             return false;
         }
 
-        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(
+        public override AdjustNewLinesOperation GetAdjustNewLinesOperation(
             in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
             if (IsQuestionOrColonOfNewConditional(currentToken))

--- a/src/Analyzers/VisualBasic/CodeFixes/UseConditionalExpression/MultiLineConditionalExpressionFormattingRule.vb
+++ b/src/Analyzers/VisualBasic/CodeFixes/UseConditionalExpression/MultiLineConditionalExpressionFormattingRule.vb
@@ -39,7 +39,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UseConditionalExpression
         End Function
 
         Public Overrides Function GetAdjustNewLinesOperationSlow(
-                ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation?
+                ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation
             If IsCommaOfNewConditional(previousToken) Then
                 ' We want to force the expressions after the commas to be put on the 
                 ' next line.

--- a/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.PasteFormattingRule.cs
+++ b/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.PasteFormattingRule.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting
     {
         internal class PasteFormattingRule : AbstractFormattingRule
         {
-            public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+            public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
             {
                 if (currentToken.Parent != null)
                 {

--- a/src/EditorFeatures/VisualBasic/Utilities/LineAdjustmentFormattingRule.vb
+++ b/src/EditorFeatures/VisualBasic/Utilities/LineAdjustmentFormattingRule.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Utilities
         Private Sub New()
         End Sub
 
-        Public Overrides Function GetAdjustNewLinesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation?
+        Public Overrides Function GetAdjustNewLinesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation
             If Not CommonFormattingHelpers.HasAnyWhitespaceElasticTrivia(previousToken, currentToken) Then
                 Return nextOperation.Invoke(previousToken, currentToken)
             End If

--- a/src/Features/CSharp/Portable/BraceCompletion/CurlyBraceCompletionService.cs
+++ b/src/Features/CSharp/Portable/BraceCompletion/CurlyBraceCompletionService.cs
@@ -361,7 +361,7 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
                 return new BraceCompletionFormattingRule(_indentStyle, cachedOptions);
             }
 
-            public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+            public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
             {
                 // If we're inside any of the following expressions check if the option for
                 // braces on new lines in object / array initializers is set before we attempt
@@ -383,7 +383,7 @@ namespace Microsoft.CodeAnalysis.CSharp.BraceCompletion
                     }
                     else
                     {
-                        return null;
+                        return AdjustNewLinesOperation.None;
                     }
                 }
 

--- a/src/Features/CSharp/Portable/ChangeSignature/ChangeSignatureFormattingRule.cs
+++ b/src/Features/CSharp/Portable/ChangeSignature/ChangeSignatureFormattingRule.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
             }
         }
 
-        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
             if (previousToken.Kind() == SyntaxKind.CommaToken && s_allowableKinds.Contains(previousToken.Parent.Kind()))
             {

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.FormattingProvider.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.FormattingProvider.cs
@@ -18,14 +18,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
             {
             }
 
-            public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+            public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
             {
                 // for extract method case, for a hybrid case, don't force rule, but preserve user style
-                var operationOpt = base.GetAdjustNewLinesOperation(in previousToken, in currentToken, in nextOperation);
-                if (operationOpt == null)
-                    return null;
+                var operation = base.GetAdjustNewLinesOperation(in previousToken, in currentToken, in nextOperation);
+                if (operation.Option == AdjustNewLinesOption.None)
+                    return AdjustNewLinesOperation.None;
 
-                var operation = operationOpt.Value;
                 if (operation.Option == AdjustNewLinesOption.ForceLinesIfOnSingleLine)
                     return FormattingOperations.CreateAdjustNewLinesOperation(operation.Line, AdjustNewLinesOption.PreserveLines);
 

--- a/src/Features/CSharp/Portable/MetadataAsSource/FormattingRule.cs
+++ b/src/Features/CSharp/Portable/MetadataAsSource/FormattingRule.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MetadataAsSource
     {
         private class FormattingRule : AbstractMetadataFormattingRule
         {
-            protected override AdjustNewLinesOperation? GetAdjustNewLinesOperationBetweenMembersAndUsings(SyntaxToken token1, SyntaxToken token2)
+            protected override AdjustNewLinesOperation GetAdjustNewLinesOperationBetweenMembersAndUsings(SyntaxToken token1, SyntaxToken token2)
             {
                 var previousToken = token1;
                 var currentToken = token2;
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MetadataAsSource
                 if ((previousToken.Kind() != SyntaxKind.SemicolonToken && previousToken.Kind() != SyntaxKind.CloseBraceToken) ||
                     currentToken.Kind() == SyntaxKind.CloseBraceToken)
                 {
-                    return null;
+                    return AdjustNewLinesOperation.None;
                 }
 
                 SyntaxNode previousMember = FormattingRangeHelper.GetEnclosingMember(previousToken);
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp.MetadataAsSource
 
                 if (previousMember == null || nextMember == null || previousMember == nextMember)
                 {
-                    return null;
+                    return AdjustNewLinesOperation.None;
                 }
 
                 // If we have two members of the same kind, we won't insert a blank line 

--- a/src/Features/CSharp/Portable/UseAutoProperty/CSharpUseAutoPropertyCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseAutoProperty/CSharpUseAutoPropertyCodeFixProvider.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UseAutoProperty
                 return base.GetAdjustNewLinesOperation(in previousToken, in currentToken, in nextOperation);
             }
 
-            public override AdjustSpacesOperation? GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+            public override AdjustSpacesOperation GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
             {
                 if (ForceSingleSpace(previousToken, currentToken))
                     return new AdjustSpacesOperation(1, AdjustSpacesOption.ForceSpaces);

--- a/src/Features/CSharp/Portable/UseAutoProperty/CSharpUseAutoPropertyCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/UseAutoProperty/CSharpUseAutoPropertyCodeFixProvider.cs
@@ -110,11 +110,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UseAutoProperty
                 return false;
             }
 
-            public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+            public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
             {
                 if (ForceSingleSpace(previousToken, currentToken))
                 {
-                    return null;
+                    return AdjustNewLinesOperation.None;
                 }
 
                 return base.GetAdjustNewLinesOperation(in previousToken, in currentToken, in nextOperation);

--- a/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/AddMissingImports/AbstractAddMissingImportsFeatureService.cs
@@ -285,7 +285,7 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
             public CleanUpNewLinesFormatter(SourceText text)
                 => _text = text;
 
-            public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+            public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
             {
                 // Since we know the general shape of these new import statements, we simply look for where
                 // tokens are not on the same line and force them to only be separated by a single newline.
@@ -298,7 +298,7 @@ namespace Microsoft.CodeAnalysis.AddMissingImports
                     return FormattingOperations.CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.ForceLines);
                 }
 
-                return null;
+                return AdjustNewLinesOperation.None;
             }
         }
     }

--- a/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/FormatLargeBinaryExpressionRule.cs
+++ b/src/Features/Core/Portable/GenerateEqualsAndGetHashCodeFromMembers/FormatLargeBinaryExpressionRule.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.GenerateEqualsAndGetHashCodeFromMembers
             /// <summary>
             /// Wrap the large &amp;&amp; expression after every &amp;&amp; token.
             /// </summary>
-            public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(
+            public override AdjustNewLinesOperation GetAdjustNewLinesOperation(
                 in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
             {
                 if (_syntaxFacts.IsLogicalAndExpression(previousToken.Parent))

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService+CompatAbstractMetadataFormattingRule.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService+CompatAbstractMetadataFormattingRule.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
             [Obsolete("Do not call this method directly (it will Stack Overflow).", error: true)]
             [EditorBrowsable(EditorBrowsableState.Never)]
-            public sealed override AdjustSpacesOperation? GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+            public sealed override AdjustSpacesOperation GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
             {
                 var previousTokenCopy = previousToken;
                 var currentTokenCopy = currentToken;
@@ -103,7 +103,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             /// <summary>
             /// returns AdjustSpacesOperation between two tokens either by itself or by filtering/replacing a operation returned by NextOperation
             /// </summary>
-            public virtual AdjustSpacesOperation? GetAdjustSpacesOperationSlow(ref SyntaxToken previousToken, ref SyntaxToken currentToken, ref NextGetAdjustSpacesOperation nextOperation)
+            public virtual AdjustSpacesOperation GetAdjustSpacesOperationSlow(ref SyntaxToken previousToken, ref SyntaxToken currentToken, ref NextGetAdjustSpacesOperation nextOperation)
                 => base.GetAdjustSpacesOperation(in previousToken, in currentToken, in nextOperation);
         }
     }

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService+CompatAbstractMetadataFormattingRule.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService+CompatAbstractMetadataFormattingRule.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
             [Obsolete("Do not call this method directly (it will Stack Overflow).", error: true)]
             [EditorBrowsable(EditorBrowsableState.Never)]
-            public sealed override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+            public sealed override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
             {
                 var previousTokenCopy = previousToken;
                 var currentTokenCopy = currentToken;
@@ -97,7 +97,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             /// <summary>
             /// returns AdjustNewLinesOperation between two tokens either by itself or by filtering/replacing a operation returned by NextOperation
             /// </summary>
-            public virtual AdjustNewLinesOperation? GetAdjustNewLinesOperationSlow(ref SyntaxToken previousToken, ref SyntaxToken currentToken, ref NextGetAdjustNewLinesOperation nextOperation)
+            public virtual AdjustNewLinesOperation GetAdjustNewLinesOperationSlow(ref SyntaxToken previousToken, ref SyntaxToken currentToken, ref NextGetAdjustNewLinesOperation nextOperation)
                 => base.GetAdjustNewLinesOperation(in previousToken, in currentToken, in nextOperation);
 
             /// <summary>

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.AbstractMetadataFormattingRule.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.AbstractMetadataFormattingRule.cs
@@ -15,10 +15,10 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
     {
         protected abstract class AbstractMetadataFormattingRule : AbstractFormattingRule
         {
-            protected abstract AdjustNewLinesOperation? GetAdjustNewLinesOperationBetweenMembersAndUsings(SyntaxToken token1, SyntaxToken token2);
+            protected abstract AdjustNewLinesOperation GetAdjustNewLinesOperationBetweenMembersAndUsings(SyntaxToken token1, SyntaxToken token2);
             protected abstract bool IsNewLine(char c);
 
-            public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(
+            public override AdjustNewLinesOperation GetAdjustNewLinesOperation(
                     in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
             {
                 if (previousToken.RawKind == 0 || currentToken.RawKind == 0)
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 }
 
                 var betweenMembersAndUsingsOperation = GetAdjustNewLinesOperationBetweenMembersAndUsings(previousToken, currentToken);
-                if (betweenMembersAndUsingsOperation != null)
+                if (betweenMembersAndUsingsOperation.Option != AdjustNewLinesOption.None)
                 {
                     return betweenMembersAndUsingsOperation;
                 }

--- a/src/Features/VisualBasic/Portable/ChangeSignature/ChangeSignatureFormattingRule.vb
+++ b/src/Features/VisualBasic/Portable/ChangeSignature/ChangeSignatureFormattingRule.vb
@@ -34,7 +34,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ChangeSignature
             End If
         End Sub
 
-        Public Overrides Function GetAdjustNewLinesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation?
+        Public Overrides Function GetAdjustNewLinesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation
             If previousToken.IsKind(SyntaxKind.CommaToken) AndAlso
                (previousToken.Parent.IsKind(SyntaxKind.ParameterList) OrElse previousToken.Parent.IsKind(SyntaxKind.ArgumentList)) Then
                 Return FormattingOperations.CreateAdjustNewLinesOperation(0, AdjustNewLinesOption.PreserveLines)

--- a/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.vb
+++ b/src/Features/VisualBasic/Portable/ExtractMethod/VisualBasicMethodExtractor.vb
@@ -116,7 +116,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExtractMethod
         Private Class ExtractMethodFormattingRule
             Inherits CompatAbstractFormattingRule
 
-            Public Overrides Function GetAdjustNewLinesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation?
+            Public Overrides Function GetAdjustNewLinesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation
                 If Not previousToken.IsLastTokenOfStatement() Then
                     Return nextOperation.Invoke(previousToken, currentToken)
                 End If

--- a/src/Features/VisualBasic/Portable/MetadataAsSource/VisualBasicMetadataAsSourceService.vb
+++ b/src/Features/VisualBasic/Portable/MetadataAsSource/VisualBasicMetadataAsSourceService.vb
@@ -78,7 +78,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.MetadataAsSource
         Private Class FormattingRule
             Inherits CompatAbstractMetadataFormattingRule
 
-            Protected Overrides Function GetAdjustNewLinesOperationBetweenMembersAndUsings(token1 As SyntaxToken, token2 As SyntaxToken) As AdjustNewLinesOperation?
+            Protected Overrides Function GetAdjustNewLinesOperationBetweenMembersAndUsings(token1 As SyntaxToken, token2 As SyntaxToken) As AdjustNewLinesOperation
                 If token1.Kind = SyntaxKind.None OrElse token2.Kind = SyntaxKind.None Then
                     Return Nothing
                 End If

--- a/src/VisualStudio/CSharp/Impl/CodeModel/EndRegionFormattingRule.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/EndRegionFormattingRule.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
             return false;
         }
 
-        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
             if (IsAfterEndRegionBeforeMethodDeclaration(previousToken))
                 return FormattingOperations.CreateAdjustNewLinesOperation(2, AdjustNewLinesOption.ForceLines);

--- a/src/VisualStudio/CSharp/Impl/Utilities/BlankLineInGeneratedMethodFormattingRule.cs
+++ b/src/VisualStudio/CSharp/Impl/Utilities/BlankLineInGeneratedMethodFormattingRule.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Utilities
         {
         }
 
-        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
             // case: insert blank line in empty method body.
             if (previousToken.Kind() == SyntaxKind.OpenBraceToken &&

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocumentPreserveFormattingRule.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocumentPreserveFormattingRule.cs
@@ -27,10 +27,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             return operation;
         }
 
-        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
             var operation = base.GetAdjustNewLinesOperation(in previousToken, in currentToken, in nextOperation);
-            if (operation != null)
+            if (operation.Option != AdjustNewLinesOption.None)
             {
                 return s_preserveLine;
             }

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocumentPreserveFormattingRule.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocumentPreserveFormattingRule.cs
@@ -16,10 +16,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
         private static readonly AdjustSpacesOperation s_preserveSpace = FormattingOperations.CreateAdjustSpacesOperation(0, AdjustSpacesOption.PreserveSpaces);
         private static readonly AdjustNewLinesOperation s_preserveLine = FormattingOperations.CreateAdjustNewLinesOperation(0, AdjustNewLinesOption.PreserveLines);
 
-        public override AdjustSpacesOperation? GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+        public override AdjustSpacesOperation GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
         {
             var operation = base.GetAdjustSpacesOperation(in previousToken, in currentToken, in nextOperation);
-            if (operation != null)
+            if (operation.Option != AdjustSpacesOption.None)
             {
                 return s_preserveSpace;
             }

--- a/src/Workspaces/CSharp/Portable/Indentation/CSharpIndentationService.cs
+++ b/src/Workspaces/CSharp/Portable/Indentation/CSharpIndentationService.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Indentation
             }
 
             var lineOperation = FormattingOperations.GetAdjustNewLinesOperation(formattingRules, previousToken, token, optionSet.AsAnalyzerConfigOptions(optionService, LanguageNames.CSharp));
-            if (lineOperation == null || lineOperation.Value.Option == AdjustNewLinesOption.ForceLinesIfOnSingleLine)
+            if (lineOperation.Option == AdjustNewLinesOption.None || lineOperation.Option == AdjustNewLinesOption.ForceLinesIfOnSingleLine)
             {
                 // no indentation operation, nothing to do for smart token formatter
                 return false;

--- a/src/Workspaces/CSharp/Portable/Indentation/CSharpSmartTokenFormatter.cs
+++ b/src/Workspaces/CSharp/Portable/Indentation/CSharpSmartTokenFormatter.cs
@@ -122,16 +122,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Indentation
 
         private class NoLineChangeFormattingRule : AbstractFormattingRule
         {
-            public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+            public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
             {
                 // no line operation. no line changes what so ever
                 var lineOperation = base.GetAdjustNewLinesOperation(in previousToken, in currentToken, in nextOperation);
-                if (lineOperation != null)
+                if (lineOperation.Option != AdjustNewLinesOption.None)
                 {
                     // ignore force if same line option
-                    if (lineOperation.Value.Option == AdjustNewLinesOption.ForceLinesIfOnSingleLine)
+                    if (lineOperation.Option == AdjustNewLinesOption.ForceLinesIfOnSingleLine)
                     {
-                        return null;
+                        return AdjustNewLinesOperation.None;
                     }
 
                     // basically means don't ever put new line if there isn't already one, but do
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Indentation
                     return FormattingOperations.CreateAdjustNewLinesOperation(line: 0, option: AdjustNewLinesOption.PreserveLines);
                 }
 
-                return null;
+                return AdjustNewLinesOperation.None;
             }
         }
 

--- a/src/Workspaces/CSharp/Portable/Indentation/CSharpSmartTokenFormatter.cs
+++ b/src/Workspaces/CSharp/Portable/Indentation/CSharpSmartTokenFormatter.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Indentation
                 // don't suppress anything
             }
 
-            public override AdjustSpacesOperation? GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+            public override AdjustSpacesOperation GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
             {
                 var spaceOperation = base.GetAdjustSpacesOperation(in previousToken, in currentToken, in nextOperation);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/DefaultOperationProvider.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/DefaultOperationProvider.cs
@@ -35,8 +35,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         {
         }
 
-        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
-            => null;
+        public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+            => AdjustNewLinesOperation.None;
 
         // return 1 space for every token pairs as a default operation
         public override AdjustSpacesOperation? GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/DefaultOperationProvider.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/DefaultOperationProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             => AdjustNewLinesOperation.None;
 
         // return 1 space for every token pairs as a default operation
-        public override AdjustSpacesOperation? GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+        public override AdjustSpacesOperation GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
         {
             var space = currentToken.Kind() == SyntaxKind.EndOfFileToken ? 0 : 1;
             return FormattingOperations.CreateAdjustSpacesOperation(space, AdjustSpacesOption.DefaultSpacesIfOnSingleLine);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/CSharpTriviaFormatter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Engine/Trivia/CSharpTriviaFormatter.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -70,7 +71,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             // [trivia] [whitespace] [token] case
             if (trivia2.IsKind(SyntaxKind.None))
             {
-                var insertNewLine = this.FormattingRules.GetAdjustNewLinesOperation(this.Token1, this.Token2) != null;
+                var insertNewLine = this.FormattingRules.GetAdjustNewLinesOperation(this.Token1, this.Token2).Option != AdjustNewLinesOption.None;
 
                 if (IsMultilineComment(trivia1))
                 {
@@ -121,7 +122,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 // 2. Every block comment is a group of its own
                 if (!trivia1.IsKind(trivia2.Kind()) || trivia2.IsMultiLineComment() || trivia2.IsMultiLineDocComment() || existingWhitespaceBetween.Lines > 1)
                 {
-                    if (this.FormattingRules.GetAdjustNewLinesOperation(this.Token1, this.Token2) != null)
+                    if (this.FormattingRules.GetAdjustNewLinesOperation(this.Token1, this.Token2).Option != AdjustNewLinesOption.None)
                     {
                         return LineColumnRule.PreserveLinesWithDefaultIndentation(lines: 0);
                     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/ElasticTriviaFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/ElasticTriviaFormattingRule.cs
@@ -93,10 +93,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             return null;
         }
 
-        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
             var operation = nextOperation.Invoke(in previousToken, in currentToken);
-            if (operation == null)
+            if (operation.Option == AdjustNewLinesOption.None)
             {
                 // If there are more than one Type Parameter Constraint Clause then each go in separate line
                 if (CommonFormattingHelpers.HasAnyWhitespaceElasticTrivia(previousToken, currentToken) &&
@@ -122,11 +122,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                     }
                 }
 
-                return null;
+                return AdjustNewLinesOperation.None;
             }
 
             // if operation is already forced, return as it is.
-            if (operation.Value.Option == AdjustNewLinesOption.ForceLines)
+            if (operation.Option == AdjustNewLinesOption.ForceLines)
             {
                 return operation;
             }
@@ -137,28 +137,28 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             }
 
             var betweenMemberOperation = GetAdjustNewLinesOperationBetweenMembers(previousToken, currentToken);
-            if (betweenMemberOperation != null)
+            if (betweenMemberOperation.Option != AdjustNewLinesOption.None)
             {
                 return betweenMemberOperation;
             }
 
-            var line = Math.Max(LineBreaksAfter(previousToken, currentToken), operation.Value.Line);
+            var line = Math.Max(LineBreaksAfter(previousToken, currentToken), operation.Line);
             if (line == 0)
                 return CreateAdjustNewLinesOperation(0, AdjustNewLinesOption.PreserveLines);
 
             return CreateAdjustNewLinesOperation(line, AdjustNewLinesOption.ForceLines);
         }
 
-        private static AdjustNewLinesOperation? GetAdjustNewLinesOperationBetweenMembers(SyntaxToken previousToken, SyntaxToken currentToken)
+        private static AdjustNewLinesOperation GetAdjustNewLinesOperationBetweenMembers(SyntaxToken previousToken, SyntaxToken currentToken)
         {
             if (!FormattingRangeHelper.InBetweenTwoMembers(previousToken, currentToken))
-                return null;
+                return AdjustNewLinesOperation.None;
 
             var previousMember = FormattingRangeHelper.GetEnclosingMember(previousToken);
             var nextMember = FormattingRangeHelper.GetEnclosingMember(currentToken);
             if (previousMember == null || nextMember == null)
             {
-                return null;
+                return AdjustNewLinesOperation.None;
             }
 
             // see whether first non whitespace trivia after before the current member is a comment or not

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/ElasticTriviaFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/ElasticTriviaFormattingRule.cs
@@ -213,14 +213,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             return FormattingOperations.CreateAdjustNewLinesOperation(2 /* +1 for member itself and +1 for a blank line*/, AdjustNewLinesOption.ForceLines);
         }
 
-        public override AdjustSpacesOperation? GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+        public override AdjustSpacesOperation GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
         {
             var operation = nextOperation.Invoke(in previousToken, in currentToken);
-            if (operation == null)
-                return null;
+            if (operation.Option == AdjustSpacesOption.None)
+                return AdjustSpacesOperation.None;
 
             // if operation is already forced, return as it is.
-            if (operation.Value.Option == AdjustSpacesOption.ForceSpaces)
+            if (operation.Option == AdjustSpacesOption.ForceSpaces)
                 return operation;
 
             if (CommonFormattingHelpers.HasAnyWhitespaceElasticTrivia(previousToken, currentToken))
@@ -239,7 +239,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
 
                 // make every operation forced
-                return CreateAdjustSpacesOperation(Math.Max(0, operation.Value.Space), AdjustSpacesOption.ForceSpaces);
+                return CreateAdjustSpacesOperation(Math.Max(0, operation.Space), AdjustSpacesOption.ForceSpaces);
             }
 
             return operation;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/EndOfFileTokenFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/EndOfFileTokenFormattingRule.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
     {
         internal const string Name = "CSharp End Of File Token Formatting Rule";
 
-        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
             // * <End Of File> case for C#, make sure we don't insert new line between * and <End of
             // File> tokens.

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/EndOfFileTokenFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/EndOfFileTokenFormattingRule.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             return nextOperation.Invoke(in previousToken, in currentToken);
         }
 
-        public override AdjustSpacesOperation? GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+        public override AdjustSpacesOperation GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
         {
             // * <End Of File) case
             // for C#, make sure we have nothing between these two tokens

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/NewLineUserSettingFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/NewLineUserSettingFormattingRule.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             }
         }
 
-        public override AdjustSpacesOperation? GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+        public override AdjustSpacesOperation GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
         {
             RoslynDebug.AssertNotNull(currentToken.Parent);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/NewLineUserSettingFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/NewLineUserSettingFormattingRule.cs
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             return operation;
         }
 
-        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
             RoslynDebug.AssertNotNull(currentToken.Parent);
 
@@ -254,7 +254,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
                 else
                 {
-                    return null;
+                    return AdjustNewLinesOperation.None;
                 }
             }
 
@@ -267,7 +267,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
                 else
                 {
-                    return null;
+                    return AdjustNewLinesOperation.None;
                 }
             }
 
@@ -280,7 +280,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
                 else
                 {
-                    return null;
+                    return AdjustNewLinesOperation.None;
                 }
             }
 
@@ -293,7 +293,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
                 else
                 {
-                    return null;
+                    return AdjustNewLinesOperation.None;
                 }
             }
 
@@ -306,7 +306,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
                 else
                 {
-                    return null;
+                    return AdjustNewLinesOperation.None;
                 }
             }
 
@@ -324,7 +324,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
                 else
                 {
-                    return null;
+                    return AdjustNewLinesOperation.None;
                 }
             }
 
@@ -336,7 +336,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 (currentToken.Parent.Kind() == SyntaxKind.ArrayInitializerExpression ||
                 currentToken.Parent.Kind() == SyntaxKind.ImplicitArrayCreationExpression))
             {
-                return null;
+                return AdjustNewLinesOperation.None;
             }
 
             var currentTokenParentParent = currentToken.Parent.Parent;
@@ -354,7 +354,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
                 else
                 {
-                    return null;
+                    return AdjustNewLinesOperation.None;
                 }
             }
 
@@ -367,7 +367,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
                 else
                 {
-                    return null;
+                    return AdjustNewLinesOperation.None;
                 }
             }
 
@@ -380,7 +380,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
                 else
                 {
-                    return null;
+                    return AdjustNewLinesOperation.None;
                 }
             }
 
@@ -393,7 +393,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
                 else
                 {
-                    return null;
+                    return AdjustNewLinesOperation.None;
                 }
             }
 
@@ -407,7 +407,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
                 else
                 {
-                    return null;
+                    return AdjustNewLinesOperation.None;
                 }
             }
 
@@ -420,7 +420,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
                 else
                 {
-                    return null;
+                    return AdjustNewLinesOperation.None;
                 }
             }
 
@@ -433,7 +433,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
                 else
                 {
-                    return null;
+                    return AdjustNewLinesOperation.None;
                 }
             }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/QueryExpressionFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/QueryExpressionFormattingRule.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             }
         }
 
-        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
             if (previousToken.IsNestedQueryExpression())
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/SpacingFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/SpacingFormattingRule.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             return new SpacingFormattingRule(cachedOptions);
         }
 
-        public override AdjustSpacesOperation? GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+        public override AdjustSpacesOperation GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
         {
             RoslynDebug.Assert(previousToken.Parent != null && currentToken.Parent != null);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/StructuredTriviaFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/StructuredTriviaFormattingRule.cs
@@ -11,11 +11,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
     {
         internal const string Name = "CSharp Structured Trivia Formatting Rule";
 
-        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
             if (previousToken.Parent is StructuredTriviaSyntax || currentToken.Parent is StructuredTriviaSyntax)
             {
-                return null;
+                return AdjustNewLinesOperation.None;
             }
 
             return nextOperation.Invoke(in previousToken, in currentToken);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/StructuredTriviaFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/StructuredTriviaFormattingRule.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             return nextOperation.Invoke(in previousToken, in currentToken);
         }
 
-        public override AdjustSpacesOperation? GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+        public override AdjustSpacesOperation GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
         {
             if (previousToken.Parent is StructuredTriviaSyntax || currentToken.Parent is StructuredTriviaSyntax)
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             return new TokenBasedFormattingRule(cachedOptions);
         }
 
-        public override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
             ////////////////////////////////////////////////////
             // brace related operations
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 case SyntaxKind.OpenBraceToken:
                     if (currentToken.IsInterpolation())
                     {
-                        return null;
+                        return AdjustNewLinesOperation.None;
                     }
 
                     if (!previousToken.IsParenInParenthesizedExpression())
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 case SyntaxKind.CloseBraceToken:
                     if (currentToken.IsInterpolation())
                     {
-                        return null;
+                        return AdjustNewLinesOperation.None;
                     }
 
                     return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.PreserveLines);
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 case SyntaxKind.CloseBraceToken:
                     if (previousToken.IsInterpolation())
                     {
-                        return null;
+                        return AdjustNewLinesOperation.None;
                     }
 
                     if (!previousToken.IsCloseBraceOfExpression())
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 case SyntaxKind.OpenBraceToken:
                     if (previousToken.IsInterpolation())
                     {
-                        return null;
+                        return AdjustNewLinesOperation.None;
                     }
 
                     return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.PreserveLines);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -254,7 +254,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 _ => throw ExceptionUtilities.UnexpectedValue(node.Kind()),
             };
 
-        public override AdjustSpacesOperation? GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+        public override AdjustSpacesOperation GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
         {
             //////////////////////////////////////////////////////
             // ";" related operations

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Context/FormattingContext.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Context/FormattingContext.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Formatting
         // anchor token to anchor data map.
         // unlike anchorTree that would return anchor data for given span in the tree, it will return
         // anchorData based on key which is anchor token.
-        private readonly Dictionary<SyntaxToken, AnchorData> _anchorBaseTokenMap;
+        private readonly SegmentedDictionary<SyntaxToken, AnchorData> _anchorBaseTokenMap;
 
         // hashset to prevent duplicate entries in the trees.
         private readonly HashSet<TextSpan> _indentationMap;
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             _suppressFormattingTree = new ContextIntervalTree<SuppressSpacingData, SuppressIntervalIntrospector>(new SuppressIntervalIntrospector());
             _anchorTree = new ContextIntervalTree<AnchorData, FormattingContextIntervalIntrospector>(new FormattingContextIntervalIntrospector());
 
-            _anchorBaseTokenMap = new Dictionary<SyntaxToken, AnchorData>();
+            _anchorBaseTokenMap = new SegmentedDictionary<SyntaxToken, AnchorData>();
 
             _indentationMap = new HashSet<TextSpan>();
             _suppressWrappingMap = new HashSet<TextSpan>();
@@ -271,7 +271,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             SegmentedList<SuppressOperation> operations,
             CancellationToken cancellationToken)
         {
-            var valuePairs = new (SuppressOperation operation, bool shouldSuppress, bool onSameLine)[operations.Count];
+            var valuePairs = new SegmentedArray<(SuppressOperation operation, bool shouldSuppress, bool onSameLine)>(operations.Count);
 
             // TODO: think about a way to figure out whether it is already suppressed and skip the expensive check below.
             for (var i = 0; i < operations.Count; i++)
@@ -293,15 +293,15 @@ namespace Microsoft.CodeAnalysis.Formatting
                 valuePairs[i] = (operation, shouldSuppress: true, onSameLine);
             }
 
-            valuePairs.Do(v =>
+            foreach (var (operation, shouldSuppress, onSameLine) in valuePairs)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                if (v.shouldSuppress)
+                if (shouldSuppress)
                 {
-                    AddSuppressOperation(v.operation, v.onSameLine);
+                    AddSuppressOperation(operation, onSameLine);
                 }
-            });
+            }
         }
 
         private void AddSuppressOperation(SuppressOperation operation, bool onSameLine)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
@@ -387,12 +387,12 @@ namespace Microsoft.CodeAnalysis.Formatting
 
         private static bool AnchorOperationCandidate(TokenPairWithOperations pair)
         {
-            if (pair.LineOperation == null)
+            if (pair.LineOperation.Option == AdjustNewLinesOption.None)
             {
                 return pair.TokenStream.GetTriviaData(pair.PairIndex).SecondTokenIsFirstTokenOnLine;
             }
 
-            if (pair.LineOperation.Value.Option == AdjustNewLinesOption.ForceLinesIfOnSingleLine)
+            if (pair.LineOperation.Option == AdjustNewLinesOption.ForceLinesIfOnSingleLine)
             {
                 return !pair.TokenStream.TwoTokensOriginallyOnSameLine(pair.Token1, pair.Token2) &&
                         pair.TokenStream.GetTriviaData(pair.PairIndex).SecondTokenIsFirstTokenOnLine;
@@ -446,7 +446,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             var triviaInfo = context.TokenStream.GetTriviaData(operation.PairIndex);
             var spanBetweenTokens = TextSpan.FromBounds(token1.Span.End, token2.SpanStart);
 
-            if (operation.LineOperation != null)
+            if (operation.LineOperation.Option != AdjustNewLinesOption.None)
             {
                 if (!context.IsWrappingSuppressed(spanBetweenTokens, triviaInfo.TreatAsElastic))
                 {
@@ -454,7 +454,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                     // are conflicting each other by forcing new lines and removing new lines.
                     //
                     // if wrapping operation applied, no need to run any other operation
-                    if (applier.Apply(operation.LineOperation.Value, operation.PairIndex, cancellationToken))
+                    if (applier.Apply(operation.LineOperation, operation.PairIndex, cancellationToken))
                     {
                         return;
                     }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
@@ -183,6 +183,7 @@ namespace Microsoft.CodeAnalysis.Formatting
         }
 
         private static SegmentedList<T> AddOperations<T>(SegmentedList<SyntaxNode> nodes, Action<SegmentedList<T>, SyntaxNode> addOperations, CancellationToken cancellationToken)
+            where T : struct
         {
             var operations = new SegmentedList<T>();
             var list = new SegmentedList<T>();
@@ -192,7 +193,6 @@ namespace Microsoft.CodeAnalysis.Formatting
                 cancellationToken.ThrowIfCancellationRequested();
                 addOperations(list, n);
 
-                list.RemoveAll(item => item == null);
                 operations.AddRange(list);
                 list.Clear();
             }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/AbstractFormatEngine.cs
@@ -461,11 +461,11 @@ namespace Microsoft.CodeAnalysis.Formatting
                 }
             }
 
-            if (operation.SpaceOperation != null)
+            if (operation.SpaceOperation.Option != AdjustSpacesOption.None)
             {
                 if (!context.IsSpacingSuppressed(spanBetweenTokens, triviaInfo.TreatAsElastic))
                 {
-                    applier.Apply(operation.SpaceOperation.Value, operation.PairIndex);
+                    applier.Apply(operation.SpaceOperation, operation.PairIndex);
                 }
             }
         }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/ChainedFormattingRules.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/ChainedFormattingRules.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             action.Invoke();
         }
 
-        public AdjustNewLinesOperation? GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken)
+        public AdjustNewLinesOperation GetAdjustNewLinesOperation(SyntaxToken previousToken, SyntaxToken currentToken)
         {
             var action = new NextGetAdjustNewLinesOperation(_getAdjustNewLinesOperationRules, index: 0);
             return action.Invoke(in previousToken, in currentToken);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/ChainedFormattingRules.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/ChainedFormattingRules.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             return action.Invoke(in previousToken, in currentToken);
         }
 
-        public AdjustSpacesOperation? GetAdjustSpacesOperation(SyntaxToken previousToken, SyntaxToken currentToken)
+        public AdjustSpacesOperation GetAdjustSpacesOperation(SyntaxToken previousToken, SyntaxToken currentToken)
         {
             var action = new NextGetAdjustSpacesOperation(_getAdjustSpacesOperationRules, index: 0);
             return action.Invoke(in previousToken, in currentToken);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TokenPairWithOperations.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TokenPairWithOperations.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Formatting
     {
         public readonly TokenStream TokenStream;
         public readonly AdjustSpacesOperation? SpaceOperation;
-        public readonly AdjustNewLinesOperation? LineOperation;
+        public readonly AdjustNewLinesOperation LineOperation;
 
         public readonly int PairIndex;
 
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             TokenStream tokenStream,
             int tokenPairIndex,
             AdjustSpacesOperation? spaceOperations,
-            AdjustNewLinesOperation? lineOperations)
+            AdjustNewLinesOperation lineOperations)
         {
             Contract.ThrowIfNull(tokenStream);
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TokenPairWithOperations.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TokenPairWithOperations.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Formatting
     internal readonly struct TokenPairWithOperations
     {
         public readonly TokenStream TokenStream;
-        public readonly AdjustSpacesOperation? SpaceOperation;
+        public readonly AdjustSpacesOperation SpaceOperation;
         public readonly AdjustNewLinesOperation LineOperation;
 
         public readonly int PairIndex;
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Formatting
         public TokenPairWithOperations(
             TokenStream tokenStream,
             int tokenPairIndex,
-            AdjustSpacesOperation? spaceOperations,
+            AdjustSpacesOperation spaceOperations,
             AdjustNewLinesOperation lineOperations)
         {
             Contract.ThrowIfNull(tokenStream);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TokenStream.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Engine/TokenStream.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Formatting
         private readonly SegmentedList<SyntaxToken> _tokens;
 
         // caches original trivia info to improve perf
-        private readonly TriviaData[] _cachedOriginalTriviaInfo;
+        private readonly SegmentedArray<TriviaData> _cachedOriginalTriviaInfo;
 
         // formatting engine can be used either with syntax tree or without
         // this will reconstruct information that reside in syntax tree from root node
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 Debug.Assert(this.TokenCount > 0);
 
                 // initialize trivia related info
-                _cachedOriginalTriviaInfo = new TriviaData[this.TokenCount - 1];
+                _cachedOriginalTriviaInfo = new SegmentedArray<TriviaData>(this.TokenCount - 1);
 
                 // Func Cache
                 _getTriviaData = this.GetTriviaData;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/AbstractFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/AbstractFormattingRule.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
         /// <summary>
         /// returns AdjustSpacesOperation between two tokens either by itself or by filtering/replacing a operation returned by NextOperation
         /// </summary>
-        public virtual AdjustSpacesOperation? GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+        public virtual AdjustSpacesOperation GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
             => nextOperation.Invoke(in previousToken, in currentToken);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/AbstractFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/AbstractFormattingRule.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
         /// returns AdjustNewLinesOperation between two tokens either by itself or by filtering/replacing a operation
         /// returned by NextOperation
         /// </summary>
-        public virtual AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public virtual AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
             => nextOperation.Invoke(in previousToken, in currentToken);
 
         /// <summary>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/CompatAbstractFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/CompatAbstractFormattingRule.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
 
         [Obsolete("Do not call this method directly (it will Stack Overflow).", error: true)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public sealed override AdjustSpacesOperation? GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
+        public sealed override AdjustSpacesOperation GetAdjustSpacesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustSpacesOperation nextOperation)
         {
             var previousTokenCopy = previousToken;
             var currentTokenCopy = currentToken;
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
         /// <summary>
         /// returns AdjustSpacesOperation between two tokens either by itself or by filtering/replacing a operation returned by NextOperation
         /// </summary>
-        public virtual AdjustSpacesOperation? GetAdjustSpacesOperationSlow(ref SyntaxToken previousToken, ref SyntaxToken currentToken, ref NextGetAdjustSpacesOperation nextOperation)
+        public virtual AdjustSpacesOperation GetAdjustSpacesOperationSlow(ref SyntaxToken previousToken, ref SyntaxToken currentToken, ref NextGetAdjustSpacesOperation nextOperation)
             => base.GetAdjustSpacesOperation(in previousToken, in currentToken, in nextOperation);
     }
 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/CompatAbstractFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/CompatAbstractFormattingRule.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
 
         [Obsolete("Do not call this method directly (it will Stack Overflow).", error: true)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public sealed override AdjustNewLinesOperation? GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        public sealed override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
         {
             var previousTokenCopy = previousToken;
             var currentTokenCopy = currentToken;
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
         /// <summary>
         /// returns AdjustNewLinesOperation between two tokens either by itself or by filtering/replacing a operation returned by NextOperation
         /// </summary>
-        public virtual AdjustNewLinesOperation? GetAdjustNewLinesOperationSlow(ref SyntaxToken previousToken, ref SyntaxToken currentToken, ref NextGetAdjustNewLinesOperation nextOperation)
+        public virtual AdjustNewLinesOperation GetAdjustNewLinesOperationSlow(ref SyntaxToken previousToken, ref SyntaxToken currentToken, ref NextGetAdjustNewLinesOperation nextOperation)
             => base.GetAdjustNewLinesOperation(in previousToken, in currentToken, in nextOperation);
 
         /// <summary>

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/NextGetAdjustNewLinesOperation.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/NextGetAdjustNewLinesOperation.cs
@@ -24,12 +24,12 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
         private NextGetAdjustNewLinesOperation NextOperation
             => new(_formattingRules, _index + 1);
 
-        public AdjustNewLinesOperation? Invoke(in SyntaxToken previousToken, in SyntaxToken currentToken)
+        public AdjustNewLinesOperation Invoke(in SyntaxToken previousToken, in SyntaxToken currentToken)
         {
             // If we have no remaining handlers to execute, then we'll execute our last handler
             if (_index >= _formattingRules.Length)
             {
-                return null;
+                return AdjustNewLinesOperation.None;
             }
             else
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/NextGetAdjustSpacesOperation.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/NextGetAdjustSpacesOperation.cs
@@ -24,12 +24,12 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
         private NextGetAdjustSpacesOperation NextOperation
             => new(_formattingRules, _index + 1);
 
-        public AdjustSpacesOperation? Invoke(in SyntaxToken previousToken, in SyntaxToken currentToken)
+        public AdjustSpacesOperation Invoke(in SyntaxToken previousToken, in SyntaxToken currentToken)
         {
             // If we have no remaining handlers to execute, then we'll execute our last handler
             if (_index >= _formattingRules.Length)
             {
-                return null;
+                return AdjustSpacesOperation.None;
             }
             else
             {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/Operations/AdjustNewLinesOperation.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/Operations/AdjustNewLinesOperation.cs
@@ -11,6 +11,8 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
     /// </summary>
     internal readonly struct AdjustNewLinesOperation
     {
+        public static readonly AdjustNewLinesOperation None = default;
+
         public readonly int Line;
         public readonly AdjustNewLinesOption Option;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/Operations/AdjustNewLinesOption.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/Operations/AdjustNewLinesOption.cs
@@ -20,6 +20,10 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
     /// </summary>
     internal enum AdjustNewLinesOption
     {
+        /// <summary>
+        /// Sentinel value for <see cref="AdjustNewLinesOperation.None"/>.
+        /// </summary>
+        None,
         PreserveLines,
         ForceLines,
         ForceLinesIfOnSingleLine,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/Operations/AdjustSpacesOperation.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/Operations/AdjustSpacesOperation.cs
@@ -11,6 +11,8 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
     /// </summary>
     internal readonly struct AdjustSpacesOperation
     {
+        public static readonly AdjustSpacesOperation None = default;
+
         public readonly int Space;
         public readonly AdjustSpacesOption Option;
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/Operations/AdjustSpacesOption.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/Operations/AdjustSpacesOption.cs
@@ -10,6 +10,11 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
     internal enum AdjustSpacesOption
     {
         /// <summary>
+        /// Sentinal value for <see cref="AdjustSpacesOperation.None"/>.
+        /// </summary>
+        None,
+
+        /// <summary>
         /// Preserve spaces as it is
         /// </summary>
         PreserveSpaces,

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/Operations/FormattingOperations.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/Operations/FormattingOperations.cs
@@ -204,7 +204,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
         /// <summary>
         /// return AdjustSpacesOperation for the node provided by the given formatting rules
         /// </summary>
-        internal static AdjustSpacesOperation? GetAdjustSpacesOperation(IEnumerable<AbstractFormattingRule> formattingRules, SyntaxToken previousToken, SyntaxToken currentToken, AnalyzerConfigOptions options)
+        internal static AdjustSpacesOperation GetAdjustSpacesOperation(IEnumerable<AbstractFormattingRule> formattingRules, SyntaxToken previousToken, SyntaxToken currentToken, AnalyzerConfigOptions options)
         {
             var chainedFormattingRules = new ChainedFormattingRules(formattingRules, options);
             return chainedFormattingRules.GetAdjustSpacesOperation(previousToken, currentToken);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/Operations/FormattingOperations.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/Operations/FormattingOperations.cs
@@ -195,7 +195,7 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
         /// <summary>
         /// return AdjustNewLinesOperation for the node provided by the given formatting rules
         /// </summary>
-        internal static AdjustNewLinesOperation? GetAdjustNewLinesOperation(IEnumerable<AbstractFormattingRule> formattingRules, SyntaxToken previousToken, SyntaxToken currentToken, AnalyzerConfigOptions options)
+        internal static AdjustNewLinesOperation GetAdjustNewLinesOperation(IEnumerable<AbstractFormattingRule> formattingRules, SyntaxToken previousToken, SyntaxToken currentToken, AnalyzerConfigOptions options)
         {
             var chainedFormattingRules = new ChainedFormattingRules(formattingRules, options);
             return chainedFormattingRules.GetAdjustNewLinesOperation(previousToken, currentToken);

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/TriviaEngine/AbstractTriviaFormatter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/TriviaEngine/AbstractTriviaFormatter.cs
@@ -366,17 +366,16 @@ namespace Microsoft.CodeAnalysis.Formatting
             }
 
             // use line defined by the token formatting rules
-            var lineOperationOpt = this.FormattingRules.GetAdjustNewLinesOperation(token1, token2);
+            var lineOperation = this.FormattingRules.GetAdjustNewLinesOperation(token1, token2);
 
             // there is existing lines, but no line operation
-            if (existingWhitespaceBetween.Lines != 0 && lineOperationOpt == null)
+            if (existingWhitespaceBetween.Lines != 0 && lineOperation.Option == AdjustNewLinesOption.None)
             {
                 return defaultRule;
             }
 
-            if (lineOperationOpt != null)
+            if (lineOperation.Option != AdjustNewLinesOption.None)
             {
-                var lineOperation = lineOperationOpt.Value;
                 switch (lineOperation.Option)
                 {
                     case AdjustNewLinesOption.PreserveLines:

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/TriviaEngine/AbstractTriviaFormatter.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/TriviaEngine/AbstractTriviaFormatter.cs
@@ -403,16 +403,16 @@ namespace Microsoft.CodeAnalysis.Formatting
 
             // use space defined by the regular formatting rules
             var spaceOperation = this.FormattingRules.GetAdjustSpacesOperation(token1, token2);
-            if (spaceOperation == null)
+            if (spaceOperation.Option == AdjustSpacesOption.None)
                 return defaultRule;
 
-            if (spaceOperation.Value.Option == AdjustSpacesOption.DefaultSpacesIfOnSingleLine &&
-                spaceOperation.Value.Space == 1)
+            if (spaceOperation.Option == AdjustSpacesOption.DefaultSpacesIfOnSingleLine &&
+                spaceOperation.Space == 1)
             {
                 return defaultRule;
             }
 
-            return defaultRule.With(spaces: spaceOperation.Value.Space);
+            return defaultRule.With(spaces: spaceOperation.Space);
         }
 
         /// <summary>

--- a/src/Workspaces/VisualBasic/Portable/Formatting/DefaultOperationProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/DefaultOperationProvider.vb
@@ -210,7 +210,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
         End Function
 
         ' return 1 space for every token pairs as a default operation
-        Public Overrides Function GetAdjustSpacesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustSpacesOperation) As AdjustSpacesOperation?
+        Public Overrides Function GetAdjustSpacesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustSpacesOperation) As AdjustSpacesOperation
             If previousToken.Kind = SyntaxKind.ColonToken AndAlso
                TypeOf previousToken.Parent Is LabelStatementSyntax AndAlso
                currentToken.Kind <> SyntaxKind.EndOfFileToken Then

--- a/src/Workspaces/VisualBasic/Portable/Formatting/DefaultOperationProvider.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/DefaultOperationProvider.vb
@@ -57,7 +57,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
         Public Overrides Function GetAdjustNewLinesOperationSlow(
                 ByRef previousToken As SyntaxToken,
                 ByRef currentToken As SyntaxToken,
-                ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation?
+                ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation
             If previousToken.Parent Is Nothing Then
                 Return Nothing
             End If

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/VisualBasicTriviaFormatter.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/VisualBasicTriviaFormatter.vb
@@ -5,6 +5,7 @@
 Imports System.Threading
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Formatting
+Imports Microsoft.CodeAnalysis.Formatting.Rules
 Imports Microsoft.CodeAnalysis.PooledObjects
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -96,7 +97,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
 
             ' [trivia] [whitespace] [token] case
             If trivia2.Kind = SyntaxKind.None Then
-                Dim insertNewLine = Me.FormattingRules.GetAdjustNewLinesOperation(Me.Token1, Me.Token2) IsNot Nothing
+                Dim insertNewLine = Me.FormattingRules.GetAdjustNewLinesOperation(Me.Token1, Me.Token2).Option <> AdjustNewLinesOption.None
 
                 If insertNewLine Then
                     Return LineColumnRule.PreserveLinesWithDefaultIndentation(lines:=0)
@@ -133,7 +134,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
                     Return LineColumnRule.PreserveSpacesOrUseDefaultIndentation(spaces:=1)
                 End If
 
-                If Me.FormattingRules.GetAdjustNewLinesOperation(Me.Token1, Me.Token2) IsNot Nothing Then
+                If Me.FormattingRules.GetAdjustNewLinesOperation(Me.Token1, Me.Token2).Option <> AdjustNewLinesOption.None Then
                     Return LineColumnRule.PreserveLinesWithDefaultIndentation(lines:=0)
                 End If
 

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Rules/AdjustSpaceFormattingRule.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Rules/AdjustSpaceFormattingRule.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
         Public Sub New()
         End Sub
 
-        Public Overrides Function GetAdjustSpacesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextFunc As NextGetAdjustSpacesOperation) As AdjustSpacesOperation?
+        Public Overrides Function GetAdjustSpacesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextFunc As NextGetAdjustSpacesOperation) As AdjustSpacesOperation
             ' * <end of file token>
             If currentToken.Kind = SyntaxKind.EndOfFileToken Then
                 Return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine)

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Rules/ElasticTriviaFormattingRule.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Rules/ElasticTriviaFormattingRule.vb
@@ -88,7 +88,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             End If
         End Sub
 
-        Public Overrides Function GetAdjustSpacesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustSpacesOperation) As AdjustSpacesOperation?
+        Public Overrides Function GetAdjustSpacesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustSpacesOperation) As AdjustSpacesOperation
             ' if it doesn't have elastic trivia, pass it through
             If Not CommonFormattingHelpers.HasAnyWhitespaceElasticTrivia(previousToken, currentToken) Then
                 Return nextOperation.Invoke(previousToken, currentToken)
@@ -97,7 +97,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             ' if it has one, check whether there is a forced one
             Dim operation = nextOperation.Invoke(previousToken, currentToken)
 
-            If operation IsNot Nothing AndAlso operation.Value.Option = AdjustSpacesOption.ForceSpaces Then
+            If operation.Option = AdjustSpacesOption.ForceSpaces Then
                 Return operation
             End If
 

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Rules/ElasticTriviaFormattingRule.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Rules/ElasticTriviaFormattingRule.vb
@@ -127,7 +127,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
         Public Overrides Function GetAdjustNewLinesOperationSlow(
                 ByRef previousToken As SyntaxToken,
                 ByRef currentToken As SyntaxToken,
-                ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation?
+                ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation
 
             ' if it doesn't have elastic trivia, pass it through
             If Not CommonFormattingHelpers.HasAnyWhitespaceElasticTrivia(previousToken, currentToken) Then
@@ -137,7 +137,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             ' if it has one, check whether there is a forced one
             Dim operation = nextOperation.Invoke(previousToken, currentToken)
 
-            If operation IsNot Nothing AndAlso operation.Value.Option = AdjustNewLinesOption.ForceLines Then
+            If operation.Option = AdjustNewLinesOption.ForceLines Then
                 Return operation
             End If
 
@@ -220,7 +220,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
                     Return FormattingOperations.CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.PreserveLines)
                 End If
 
-                Return CreateAdjustNewLinesOperation(Math.Max(If(operation Is Nothing, 1, operation.Value.Line), 0), AdjustNewLinesOption.PreserveLines)
+                Return CreateAdjustNewLinesOperation(Math.Max(If(operation.Option = AdjustNewLinesOption.None, 1, operation.Line), 0), AdjustNewLinesOption.PreserveLines)
             End If
 
             If lines = 0 Then

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Rules/StructuredTriviaFormattingRule.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Rules/StructuredTriviaFormattingRule.vb
@@ -21,7 +21,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
             Return nextOperation.Invoke(previousToken, currentToken)
         End Function
 
-        Public Overrides Function GetAdjustSpacesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustSpacesOperation) As AdjustSpacesOperation?
+        Public Overrides Function GetAdjustSpacesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustSpacesOperation) As AdjustSpacesOperation
             If UnderStructuredTrivia(previousToken, currentToken) Then
                 If previousToken.Kind = SyntaxKind.HashToken AndAlso SyntaxFacts.IsPreprocessorKeyword(CType(currentToken.Kind, SyntaxKind)) Then
                     Return CreateAdjustSpacesOperation(space:=0, option:=AdjustSpacesOption.ForceSpacesIfOnSingleLine)

--- a/src/Workspaces/VisualBasic/Portable/Formatting/Rules/StructuredTriviaFormattingRule.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Rules/StructuredTriviaFormattingRule.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
         Public Sub New()
         End Sub
 
-        Public Overrides Function GetAdjustNewLinesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation?
+        Public Overrides Function GetAdjustNewLinesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation
             If UnderStructuredTrivia(previousToken, currentToken) Then
                 Return Nothing
             End If

--- a/src/Workspaces/VisualBasic/Portable/Indentation/SpecialFormattingOperation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Indentation/SpecialFormattingOperation.vb
@@ -43,13 +43,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Indentation
             Return Nothing
         End Function
 
-        Public Overrides Function GetAdjustSpacesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustSpacesOperation) As AdjustSpacesOperation?
+        Public Overrides Function GetAdjustSpacesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustSpacesOperation) As AdjustSpacesOperation
             Dim spaceOperation = MyBase.GetAdjustSpacesOperationSlow(previousToken, currentToken, nextOperation)
 
             ' if there is force space operation, convert it to ForceSpaceIfSingleLine operation.
             ' (force space basically means remove all line breaks)
-            If spaceOperation IsNot Nothing AndAlso spaceOperation.Value.Option = AdjustSpacesOption.ForceSpaces Then
-                Return FormattingOperations.CreateAdjustSpacesOperation(spaceOperation.Value.Space, AdjustSpacesOption.ForceSpacesIfOnSingleLine)
+            If spaceOperation.Option = AdjustSpacesOption.ForceSpaces Then
+                Return FormattingOperations.CreateAdjustSpacesOperation(spaceOperation.Space, AdjustSpacesOption.ForceSpacesIfOnSingleLine)
             End If
 
             Return spaceOperation

--- a/src/Workspaces/VisualBasic/Portable/Indentation/SpecialFormattingOperation.vb
+++ b/src/Workspaces/VisualBasic/Portable/Indentation/SpecialFormattingOperation.vb
@@ -24,7 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Indentation
             ' don't suppress anything
         End Sub
 
-        Public Overrides Function GetAdjustNewLinesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation?
+        Public Overrides Function GetAdjustNewLinesOperationSlow(ByRef previousToken As SyntaxToken, ByRef currentToken As SyntaxToken, ByRef nextOperation As NextGetAdjustNewLinesOperation) As AdjustNewLinesOperation
 
             ' unlike regular one. force position of attribute
             Dim attributeNode = TryCast(previousToken.Parent, AttributeListSyntax)
@@ -34,7 +34,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Indentation
 
             ' no line operation. no line changes what so ever
             Dim lineOperation = MyBase.GetAdjustNewLinesOperationSlow(previousToken, currentToken, nextOperation)
-            If lineOperation IsNot Nothing Then
+            If lineOperation.Option <> AdjustNewLinesOption.None Then
                 ' basically means don't ever put new line if there isn't already one, but do
                 ' indentation.
                 Return FormattingOperations.CreateAdjustNewLinesOperation(line:=0, option:=AdjustNewLinesOption.PreserveLines)

--- a/src/Workspaces/VisualBasic/Portable/Indentation/VisualBasicIndentationService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Indentation/VisualBasicIndentationService.vb
@@ -92,7 +92,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Indentation
 
             ' now, regular case. ask formatting rule to see whether we should use token formatter or not
             Dim lineOperation = FormattingOperations.GetAdjustNewLinesOperation(formattingRules, previousToken, token, options)
-            If lineOperation IsNot Nothing AndAlso lineOperation.Value.Option <> AdjustNewLinesOption.ForceLinesIfOnSingleLine Then
+            If lineOperation.Option <> AdjustNewLinesOption.None AndAlso lineOperation.Option <> AdjustNewLinesOption.ForceLinesIfOnSingleLine Then
                 Return True
             End If
 


### PR DESCRIPTION
Applies improvements to dotnet/roslyn#42863