### PR TITLE
Add tests for underlining reassignments

### DIFF
--- a/src/EditorFeatures/CSharpTest/ReassignedVariable/CSharpReassignedVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/ReassignedVariable/CSharpReassignedVariableTests.cs
@@ -285,5 +285,322 @@ class C
     }
 }");
         }
+
+        [Fact]
+        public async Task TestLocalDeclaredByPattern()
+        {
+            await TestAsync(
+@"
+using System;
+class C
+{
+    void M()
+    {
+        if (0 is var [|p|]) [|p|] = 0;
+        Console.WriteLine([|p|]);
+    }
+}");
+        }
+
+        [Fact]
+        public async Task TestLocalDeclaredByOutVar()
+        {
+            await TestAsync(
+@"
+using System;
+class C
+{
+    void M()
+    {
+        M2(out var [|p|]);
+        [|p|] = 0;
+        Console.WriteLine([|p|]);
+    }
+
+    void M2(out int p) => p = 0;
+}");
+        }
+
+        [Fact]
+        public async Task TestOutParameterCausingReassignment()
+        {
+            await TestAsync(
+@"
+using System;
+class C
+{
+    void M()
+    {
+        int [|p|] = 0;
+        M2(out [|p|]);
+        Console.WriteLine([|p|]);
+    }
+
+    void M2(out int p) => p = 0;
+}");
+        }
+
+        [Fact]
+        public async Task TestOutParameterWithoutReassignment()
+        {
+            await TestAsync(
+@"
+using System;
+class C
+{
+    void M()
+    {
+        int p;
+        M2(out p);
+        Console.WriteLine(p);
+    }
+
+    void M2(out int p) => p = 0;
+}");
+        }
+
+        [Fact]
+        public async Task AssignmentThroughOutParameterIsNotAssignmentOfTheVariableItself()
+        {
+            await TestAsync(
+@"
+using System;
+class C
+{
+    void M(out int p)
+    {
+        p = 0;
+        p = 1;
+        Console.WriteLine(p);
+    }
+}");
+        }
+
+        [Fact]
+        public async Task TestOutParameterReassignment()
+        {
+            await TestAsync(
+@"
+using System;
+class C
+{
+    void M(out int [|p|])
+    {
+        [|p|] = ref [|p|];
+        Console.WriteLine([|p|]);
+    }
+}");
+        }
+
+        [Fact]
+        public async Task AssignmentThroughRefParameterIsNotAssignmentOfTheVariableItself()
+        {
+            await TestAsync(
+@"
+using System;
+class C
+{
+    void M(ref int p)
+    {
+        p = 0;
+        p = 1;
+        Console.WriteLine(p);
+    }
+}");
+        }
+
+        [Fact]
+        public async Task TestRefParameterReassignment()
+        {
+            await TestAsync(
+@"
+using System;
+class C
+{
+    void M(ref int [|p|])
+    {
+        [|p|] = ref [|p|];
+        Console.WriteLine([|p|]);
+    }
+}");
+        }
+
+        [Fact]
+        public async Task AssignmentThroughRefLocalIsNotAssignmentOfTheVariableItself()
+        {
+            await TestAsync(
+@"
+using System;
+class C
+{
+    void M(ref int p)
+    {
+        ref var local = ref p;
+        local = 0;
+        local = 1;
+        Console.WriteLine(local);
+    }
+}");
+        }
+
+        [Fact]
+        public async Task TestRefLocalReassignment()
+        {
+            await TestAsync(
+@"
+using System;
+class C
+{
+    void M(ref int p)
+    {
+        ref var [|local|] = ref p;
+        [|local|] = ref p;
+        Console.WriteLine([|local|]);
+    }
+}");
+        }
+
+        [Fact]
+        public async Task AssignmentThroughPointerIsNotAssignmentOfTheVariableItself()
+        {
+            await TestAsync(
+@"
+using System;
+class C
+{
+    unsafe void M(int* p)
+    {
+        *p = 4;
+        Console.WriteLine((IntPtr)p);
+    }
+}");
+        }
+
+        [Fact]
+        public async Task TestPointerVariableReassignment()
+        {
+            await TestAsync(
+@"
+using System;
+class C
+{
+    unsafe void M(int* [|p|])
+    {
+        [|p|] = null;
+        Console.WriteLine((IntPtr)p);
+    }
+}");
+        }
+
+        [Fact]
+        public async Task TestRefParameterCausingPossibleReassignment()
+        {
+            await TestAsync(
+@"
+using System;
+class C
+{
+    void M()
+    {
+        int [|p|] = 0;
+        M2(ref [|p|]);
+        Console.WriteLine([|p|]);
+    }
+
+    void M2(ref int p) { }
+}");
+        }
+
+        [Fact]
+        public async Task TestRefParameterWithoutReassignment()
+        {
+            await TestAsync(
+@"
+using System;
+class C
+{
+    void M()
+    {
+        int p;
+        M2(ref p);
+        Console.WriteLine(p);
+    }
+
+    void M2(ref int p) { }
+}");
+        }
+
+        [Fact]
+        public async Task TestRefLocalCausingPossibleReassignment()
+        {
+            await TestAsync(
+@"
+using System;
+class C
+{
+    void M()
+    {
+        int [|p|] = 0;
+        ref int refP = ref [|p|];
+        Console.WriteLine([|p|]);
+    }
+}");
+        }
+
+        [Fact]
+        public async Task TestPointerCausingPossibleReassignment()
+        {
+            await TestAsync(
+@"
+using System;
+class C
+{
+    unsafe void M()
+    {
+        int [|p|] = 0;
+        int* pointer = &[|p|];
+        Console.WriteLine([|p|]);
+    }
+}");
+        }
+
+        [Fact]
+        public async Task TestRefExtensionMethodCausingPossibleReassignment()
+        {
+            await TestAsync(
+@"
+using System;
+static class C
+{
+    void M()
+    {
+        int [|p|] = 0;
+        [|p|].M2();
+        Console.WriteLine([|p|]);
+    }
+
+    static void M2(this ref int p) { }
+}");
+        }
+
+        [Fact]
+        public async Task TestMutatingStructMethod()
+        {
+            await TestAsync(
+@"
+using System;
+struct S
+{
+    int f;
+
+    void M(S p)
+    {
+        p.MutatingMethod();
+        Console.WriteLine(p);
+    }
+
+    void MutatingMethod() => this = default;
+}");
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/ReassignedVariable/VisualBasicReassignedVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ReassignedVariable/VisualBasicReassignedVariableTests.vb
@@ -1,0 +1,327 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.ReassignedVariable
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+
+Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ReassignedVariable
+    Public Class VisualBasicReassignedVariableTests
+        Inherits AbstractReassignedVariableTests
+
+        Protected Overrides Function CreateWorkspace(markup As String) As TestWorkspace
+            Return TestWorkspace.CreateVisualBasic(markup)
+        End Function
+
+        <Fact>
+        Public Async Function TestNoParameterReassignment() As Task
+            Await TestAsync(
+"Class C
+    Sub M(p As Integer)
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestParameterReassignment() As Task
+            Await TestAsync(
+"Class C
+    Sub M([|p|] As Integer)
+        [|p|] = 1
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestParameterReassignmentWhenReadAfter() As Task
+            Await TestAsync(
+"
+Imports System
+Class C
+    Sub M([|p|] As Integer)
+        [|p|] = 1
+        Console.WriteLine([|p|])
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestParameterReassignmentWhenReadBefore() As Task
+            Await TestAsync(
+"
+Imports System
+Class C
+    Sub M([|p|] As Integer)
+        Console.WriteLine([|p|])
+        [|p|] = 1
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestParameterReassignmentWhenReadWithDefaultValue() As Task
+            Await TestAsync(
+"
+Imports System
+Class C
+    Sub M([|p|] As Integer = 1)
+        Console.WriteLine([|p|])
+        [|p|] = 1
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestIndexerWithWriteInGetter() As Task
+            Await TestAsync(
+"
+Imports System
+Class C
+    Default Property Item([|p|] As Integer) As Integer
+        Get
+            [|p|] += 1
+            Return [|p|]
+        End Get
+    End Property
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestIndexerWithWriteInSetter() As Task
+            Await TestAsync(
+"
+Imports System
+Class C
+    Default Property Item([|p|] As Integer) As Integer
+        Set(ByVal value As Integer)
+            [|p|] += 1
+        End Set
+    End Property
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestPropertyWithAssignmentToValue() As Task
+            Await TestAsync(
+"
+Imports System
+Class C
+    Property Goo As Integer
+        Set(ByVal [|value|] As Integer)
+            [|value|] = [|value|] + 1
+        End Set
+    End Property
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestLambdaParameterWithoutReassignment() As Task
+            Await TestAsync(
+"
+Imports System
+Class C
+    Sub M()
+        Dim a As Action(Of Integer) = Sub(x) Console.WriteLine(x)
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestLambdaParameterWithReassignment() As Task
+            Await TestAsync(
+"
+Imports System
+Class C
+    Sub M()
+        Dim a As Action(Of Integer) =
+            Sub([|x|])
+                [|x|] += 1
+                Console.WriteLine([|x|])
+            End Sub
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestLambdaParameterWithReassignment2() As Task
+            Await TestAsync(
+"
+Imports System
+Class C
+    Sub M()
+        Dim a As Action(Of Integer) =
+            Sub([|x|] As Integer)
+                [|x|] += 1
+                Console.WriteLine([|x|])
+            End Sub
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestLocalWithoutInitializerWithoutReassignment() As Task
+            Await TestAsync(
+"
+Imports System
+Class C
+    Sub M(b As Boolean)
+        Dim p As Integer
+        If b Then p = 1 Else p = 2
+
+        Console.WriteLine(p)
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestLocalWithoutInitializerWithReassignment() As Task
+            Await TestAsync(
+"
+Imports System
+Class C
+    Sub M(b As Boolean)
+        Dim [|p|] As Integer
+        If b Then [|p|] = 1 Else [|p|] = 2
+
+        [|p|] = 0
+        Console.WriteLine([|p|])
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestOutParameterCausingReassignment() As Task
+            Await TestAsync(
+"
+Imports System
+Class C
+    Sub M()
+        Dim [|p|] As Integer = 0
+        M2([|p|])
+        Console.WriteLine([|p|])
+    End Sub
+
+    Sub M2(<System.Runtime.InteropServices.Out> ByRef p As Integer)
+        p = 0
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestOutParameterWithoutReassignment() As Task
+            Await TestAsync(
+"
+Imports System
+Class C
+    Sub M()
+        Dim p As Integer
+        M2(p)
+        Console.WriteLine(p)
+    End Sub
+
+    Sub M2(<System.Runtime.InteropServices.Out> ByRef p As Integer)
+        p = 0
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function AssignmentThroughOutParameterIsNotAssignmentOfTheVariableItself() As Task
+            Await TestAsync(
+"
+Imports System
+Class C
+    Sub M(<System.Runtime.InteropServices.Out> ByRef p As Integer)
+        p = 0
+        p = 1
+        Console.WriteLine(p)
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function AssignmentThroughRefParameterIsNotAssignmentOfTheVariableItself() As Task
+            Await TestAsync(
+"
+Imports System
+Class C
+    Sub M(ByRef p As Integer)
+        p = 0
+        p = 1
+        Console.WriteLine(p)
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestRefParameterCausingPossibleReassignment() As Task
+            Await TestAsync(
+"
+Imports System
+Class C
+    Sub M()
+        Dim [|p|] As Integer = 0
+        M2([|p|])
+        Console.WriteLine([|p|])
+    End Sub
+
+    Sub M2(ByRef p As Integer)
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestRefParameterWithoutReassignment() As Task
+            Await TestAsync(
+"
+Imports System
+Class C
+    Sub M()
+        Dim p As Integer
+        M2(p)
+        Console.WriteLine(p)
+    End Sub
+
+    Sub M2(ByRef p As Integer)
+    End Sub
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestRefExtensionMethodCausingPossibleReassignment() As Task
+            Await TestAsync(
+"
+Imports System
+Module C
+    Sub M()
+        Dim [|p|] As Integer = 0
+        [|p|].M2()
+        Console.WriteLine([|p|])
+    End Sub
+
+    <System.Runtime.CompilerServices.Extension>
+    Sub M2(ByRef p As Integer)
+    End Sub
+End Module")
+        End Function
+
+        <Fact>
+        Public Async Function TestMutatingStructMethod() As Task
+            Await TestAsync(
+"
+Imports System
+Structure S
+    f As Integer
+
+    Sub M(p As S)
+        p.MutatingMethod()
+        Console.WriteLine(p)
+    End Sub
+
+    Sub MutatingMethod()
+        Me = Nothing
+    End Sub
+End Structure")
+        End Function
+    End Class
+End Namespace


### PR DESCRIPTION
Contributes to https://github.com/dotnet/roslyn/pull/51889