### PR TITLE
Add tests for underlining reassignments (second edition)

### DIFF
--- a/src/EditorFeatures/CSharpTest/ReassignedVariable/CSharpReassignedVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/ReassignedVariable/CSharpReassignedVariableTests.cs
@@ -199,6 +199,30 @@ class C
         }
 
         [Fact]
+        public async Task TestEventAddWithAssignmentToValue()
+        {
+            await TestAsync(
+@"
+using System;
+class C
+{
+    event Action Goo { add { [|value|] = null; } remove { } }
+}");
+        }
+
+        [Fact]
+        public async Task TestEventRemoveWithAssignmentToValue()
+        {
+            await TestAsync(
+@"
+using System;
+class C
+{
+    event Action Goo { add { } remove { [|value|] = null; } }
+}");
+        }
+
+        [Fact]
         public async Task TestLambdaParameterWithoutReassignment()
         {
             await TestAsync(

--- a/src/EditorFeatures/VisualBasicTest/ReassignedVariable/VisualBasicReassignedVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ReassignedVariable/VisualBasicReassignedVariableTests.vb
@@ -115,6 +115,60 @@ End Class")
         End Function
 
         <Fact>
+        Public Async Function TestEventAddWithAssignmentToValue() As Task
+            Await TestAsync(
+"
+Imports System
+Class C
+    Custom Event Goo As Action
+        AddHandler([|value|] As Action)
+            [|value|] = Nothing
+        End AddHandler
+        RemoveHandler(value As Action)
+        End RemoveHandler
+        RaiseEvent
+        End RaiseEvent
+    End Event
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestEventRemoveWithAssignmentToValue() As Task
+            Await TestAsync(
+"
+Imports System
+Class C
+    Custom Event Goo As Action
+        AddHandler(value As Action)
+        End AddHandler
+        RemoveHandler([|value|] As Action)
+            [|value|] = Nothing
+        End RemoveHandler
+        RaiseEvent
+        End RaiseEvent
+    End Event
+End Class")
+        End Function
+
+        <Fact>
+        Public Async Function TestEventRaiseWithAssignmentToValue() As Task
+            Await TestAsync(
+"
+Imports System
+Class C
+    Custom Event Goo As EventHandler
+        AddHandler(value As EventHandler)
+        End AddHandler
+        RemoveHandler(value As EventHandler)
+        End RemoveHandler
+        RaiseEvent([|sender|] As Object, e As EventArgs)
+            [|sender|] = Nothing
+        End RaiseEvent
+    End Event
+End Class")
+        End Function
+
+        <Fact>
         Public Async Function TestLambdaParameterWithoutReassignment() As Task
             Await TestAsync(
 "


### PR DESCRIPTION
Contributes to https://github.com/dotnet/roslyn/pull/51889