### PR TITLE
Add binding support for labeled break/continue

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -403,6 +403,26 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
+        /// Returns the <see cref="GeneratedLabelSymbol"/> for a break statement targeting the given label,
+        /// or the nearest enclosing loop/switch if <paramref name="labelName"/> is null.
+        /// </summary>
+        internal virtual GeneratedLabelSymbol? GetBreakLabel(string? labelName)
+        {
+            RoslynDebug.Assert(Next is object);
+            return Next.GetBreakLabel(labelName);
+        }
+
+        /// <summary>
+        /// Returns the <see cref="GeneratedLabelSymbol"/> for a continue statement targeting the given label,
+        /// or the nearest enclosing loop if <paramref name="labelName"/> is null.
+        /// </summary>
+        internal virtual GeneratedLabelSymbol? GetContinueLabel(string? labelName)
+        {
+            RoslynDebug.Assert(Next is object);
+            return Next.GetContinueLabel(labelName);
+        }
+
+        /// <summary>
         /// Get the element type of this iterator.
         /// </summary>
         /// <returns>Element type of the current iterator, or an error type.</returns>

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2947,16 +2947,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundStatement BindBreak(BreakStatementSyntax node, BindingDiagnosticBag diagnostics)
         {
-            if (node.Name != null)
-            {
-                MessageID.IDS_FeatureLabeledBreakContinue.CheckFeatureAvailability(diagnostics, node, node.Name.GetLocation());
-                return BindLabeledBreakOrContinue(node, node.Name, isBreak: true, diagnostics);
-            }
+            var labelName = node.Name?.Identifier.ValueText;
+            if (labelName != null)
+                MessageID.IDS_FeatureLabeledBreakContinue.CheckFeatureAvailability(diagnostics, node, node.Name!.GetLocation());
 
-            var target = this.BreakLabel;
-            if ((object)target == null)
+            var target = this.GetBreakLabel(labelName);
+            if (target == null)
             {
-                Error(diagnostics, ErrorCode.ERR_NoBreakOrCont, node);
+                Error(diagnostics, labelName != null ? ErrorCode.ERR_NoBreakOrContId : ErrorCode.ERR_NoBreakOrCont, node.Name ?? (SyntaxNode)node, labelName ?? "");
                 return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
             }
             return new BoundBreakStatement(node, target);
@@ -2964,88 +2962,17 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundStatement BindContinue(ContinueStatementSyntax node, BindingDiagnosticBag diagnostics)
         {
-            if (node.Name != null)
-            {
-                MessageID.IDS_FeatureLabeledBreakContinue.CheckFeatureAvailability(diagnostics, node, node.Name.GetLocation());
-                return BindLabeledBreakOrContinue(node, node.Name, isBreak: false, diagnostics);
-            }
+            var labelName = node.Name?.Identifier.ValueText;
+            if (labelName != null)
+                MessageID.IDS_FeatureLabeledBreakContinue.CheckFeatureAvailability(diagnostics, node, node.Name!.GetLocation());
 
-            var target = this.ContinueLabel;
-            if ((object)target == null)
+            var target = this.GetContinueLabel(labelName);
+            if (target == null)
             {
-                Error(diagnostics, ErrorCode.ERR_NoBreakOrCont, node);
+                Error(diagnostics, labelName != null ? ErrorCode.ERR_NoBreakOrContId : ErrorCode.ERR_NoBreakOrCont, node.Name ?? (SyntaxNode)node, labelName ?? "");
                 return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
             }
             return new BoundContinueStatement(node, target);
-        }
-
-        private BoundStatement BindLabeledBreakOrContinue(StatementSyntax node, IdentifierNameSyntax labelName, bool isBreak, BindingDiagnosticBag diagnostics)
-        {
-            var result = LookupResult.GetInstance();
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
-            this.LookupSymbolsWithFallback(result, labelName.Identifier.ValueText, arity: 0, useSiteInfo: ref useSiteInfo, options: LookupOptions.LabelsOnly);
-            diagnostics.Add(node, useSiteInfo);
-
-            if (!result.IsMultiViable)
-            {
-                result.Free();
-                Error(diagnostics, ErrorCode.ERR_LabelNotFound, labelName, labelName.Identifier.ValueText);
-                return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
-            }
-
-            var labelSymbol = (SourceLabelSymbol)result.Symbols.First();
-            result.Free();
-
-            // Walk from the label's identifier token to the LabeledStatementSyntax, then unwrap nested
-            // labels to find the actual target statement.
-            var identifierParent = labelSymbol.IdentifierNodeOrToken.Parent;
-            if (identifierParent is not LabeledStatementSyntax labeledStatement)
-            {
-                Error(diagnostics, isBreak ? ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch : ErrorCode.ERR_LabeledContinueNotOnLoop, labelName, labelName.Identifier.ValueText);
-                return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
-            }
-
-            var targetStatement = labeledStatement.Statement;
-            while (targetStatement is LabeledStatementSyntax nested)
-                targetStatement = nested.Statement;
-
-            // Verify the target statement is a loop (for continue) or loop/switch (for break).
-            bool isLoop = targetStatement is WhileStatementSyntax or DoStatementSyntax or ForStatementSyntax or ForEachStatementSyntax or ForEachVariableStatementSyntax;
-            bool isSwitch = targetStatement is SwitchStatementSyntax;
-
-            if (isBreak ? !(isLoop || isSwitch) : !isLoop)
-            {
-                Error(diagnostics, isBreak ? ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch : ErrorCode.ERR_LabeledContinueNotOnLoop, labelName, labelName.Identifier.ValueText);
-                return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
-            }
-
-            // Verify the labeled statement lexically contains this break/continue.
-            if (!targetStatement.Span.Contains(node.Span))
-            {
-                Error(diagnostics, ErrorCode.ERR_LabeledBreakContinueNotContaining, labelName, labelName.Identifier.ValueText);
-                return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
-            }
-
-            // Walk the binder chain to find the LoopBinder or SwitchBinder for the target syntax.
-            for (var binder = this; binder != null; binder = binder.Next)
-            {
-                if (binder is LoopBinder loopBinder && loopBinder.ScopeDesignator == targetStatement)
-                {
-                    var label = isBreak ? loopBinder.BreakLabel : loopBinder.ContinueLabel;
-                    return isBreak
-                        ? new BoundBreakStatement(node, label)
-                        : (BoundStatement)new BoundContinueStatement(node, label);
-                }
-
-                if (isBreak && binder is SwitchBinder switchBinder && switchBinder.ScopeDesignator == targetStatement)
-                {
-                    return new BoundBreakStatement(node, switchBinder.BreakLabel);
-                }
-            }
-
-            // Should not normally reach here if the containment check passed, but report an error defensively.
-            Error(diagnostics, ErrorCode.ERR_LabeledBreakContinueNotContaining, labelName, labelName.Identifier.ValueText);
-            return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
         }
 
         private static SwitchBinder GetSwitchBinder(Binder binder)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2957,7 +2957,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Error(diagnostics, labelName != null ? ErrorCode.ERR_NoBreakOrContId : ErrorCode.ERR_NoBreakOrCont, node.Name ?? (SyntaxNode)node, labelName ?? "");
                 return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
             }
-            return new BoundBreakStatement(node, target);
+            return new BoundBreakStatement(node, target, GetSourceLabel(node.Name));
         }
 
         private BoundStatement BindContinue(ContinueStatementSyntax node, BindingDiagnosticBag diagnostics)
@@ -2972,7 +2972,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Error(diagnostics, labelName != null ? ErrorCode.ERR_NoBreakOrContId : ErrorCode.ERR_NoBreakOrCont, node.Name ?? (SyntaxNode)node, labelName ?? "");
                 return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
             }
-            return new BoundContinueStatement(node, target);
+            return new BoundContinueStatement(node, target, GetSourceLabel(node.Name));
+        }
+
+        private LabelSymbol GetSourceLabel(IdentifierNameSyntax name)
+        {
+            if (name == null)
+                return null;
+
+            return (this.BindLabel(name, BindingDiagnosticBag.Discarded) as BoundLabel)?.Label;
         }
 
         private static SwitchBinder GetSwitchBinder(Binder binder)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2957,7 +2957,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Error(diagnostics, labelName != null ? ErrorCode.ERR_NoBreakOrContId : ErrorCode.ERR_NoBreakOrCont, node.Name ?? (SyntaxNode)node, labelName ?? "");
                 return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
             }
-            return new BoundBreakStatement(node, target, GetSourceLabel(node.Name));
+            return new BoundBreakStatement(node, target, BindLabelExpression(node.Name, diagnostics));
         }
 
         private BoundStatement BindContinue(ContinueStatementSyntax node, BindingDiagnosticBag diagnostics)
@@ -2972,15 +2972,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Error(diagnostics, labelName != null ? ErrorCode.ERR_NoBreakOrContId : ErrorCode.ERR_NoBreakOrCont, node.Name ?? (SyntaxNode)node, labelName ?? "");
                 return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
             }
-            return new BoundContinueStatement(node, target, GetSourceLabel(node.Name));
+            return new BoundContinueStatement(node, target, BindLabelExpression(node.Name, diagnostics));
         }
 
-        private LabelSymbol GetSourceLabel(IdentifierNameSyntax name)
+        private BoundLabel BindLabelExpression(IdentifierNameSyntax name, BindingDiagnosticBag diagnostics)
         {
             if (name == null)
                 return null;
 
-            return (this.BindLabel(name, BindingDiagnosticBag.Discarded) as BoundLabel)?.Label;
+            return this.BindLabel(name, diagnostics) as BoundLabel;
         }
 
         private static SwitchBinder GetSwitchBinder(Binder binder)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2947,6 +2947,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundStatement BindBreak(BreakStatementSyntax node, BindingDiagnosticBag diagnostics)
         {
+            if (node.Name != null)
+            {
+                MessageID.IDS_FeatureLabeledBreakContinue.CheckFeatureAvailability(diagnostics, node, node.Name.GetLocation());
+                return BindLabeledBreakOrContinue(node, node.Name, isBreak: true, diagnostics);
+            }
+
             var target = this.BreakLabel;
             if ((object)target == null)
             {
@@ -2958,6 +2964,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundStatement BindContinue(ContinueStatementSyntax node, BindingDiagnosticBag diagnostics)
         {
+            if (node.Name != null)
+            {
+                MessageID.IDS_FeatureLabeledBreakContinue.CheckFeatureAvailability(diagnostics, node, node.Name.GetLocation());
+                return BindLabeledBreakOrContinue(node, node.Name, isBreak: false, diagnostics);
+            }
+
             var target = this.ContinueLabel;
             if ((object)target == null)
             {
@@ -2965,6 +2977,75 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
             }
             return new BoundContinueStatement(node, target);
+        }
+
+        private BoundStatement BindLabeledBreakOrContinue(StatementSyntax node, IdentifierNameSyntax labelName, bool isBreak, BindingDiagnosticBag diagnostics)
+        {
+            var result = LookupResult.GetInstance();
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
+            this.LookupSymbolsWithFallback(result, labelName.Identifier.ValueText, arity: 0, useSiteInfo: ref useSiteInfo, options: LookupOptions.LabelsOnly);
+            diagnostics.Add(node, useSiteInfo);
+
+            if (!result.IsMultiViable)
+            {
+                result.Free();
+                Error(diagnostics, ErrorCode.ERR_LabelNotFound, labelName, labelName.Identifier.ValueText);
+                return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
+            }
+
+            var labelSymbol = (SourceLabelSymbol)result.Symbols.First();
+            result.Free();
+
+            // Walk from the label's identifier token to the LabeledStatementSyntax, then unwrap nested
+            // labels to find the actual target statement.
+            var identifierParent = labelSymbol.IdentifierNodeOrToken.Parent;
+            if (identifierParent is not LabeledStatementSyntax labeledStatement)
+            {
+                Error(diagnostics, isBreak ? ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch : ErrorCode.ERR_LabeledContinueNotOnLoop, labelName, labelName.Identifier.ValueText);
+                return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
+            }
+
+            var targetStatement = labeledStatement.Statement;
+            while (targetStatement is LabeledStatementSyntax nested)
+                targetStatement = nested.Statement;
+
+            // Verify the target statement is a loop (for continue) or loop/switch (for break).
+            bool isLoop = targetStatement is WhileStatementSyntax or DoStatementSyntax or ForStatementSyntax or ForEachStatementSyntax or ForEachVariableStatementSyntax;
+            bool isSwitch = targetStatement is SwitchStatementSyntax;
+
+            if (isBreak ? !(isLoop || isSwitch) : !isLoop)
+            {
+                Error(diagnostics, isBreak ? ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch : ErrorCode.ERR_LabeledContinueNotOnLoop, labelName, labelName.Identifier.ValueText);
+                return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
+            }
+
+            // Verify the labeled statement lexically contains this break/continue.
+            if (!targetStatement.Span.Contains(node.Span))
+            {
+                Error(diagnostics, ErrorCode.ERR_LabeledBreakContinueNotContaining, labelName, labelName.Identifier.ValueText);
+                return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
+            }
+
+            // Walk the binder chain to find the LoopBinder or SwitchBinder for the target syntax.
+            for (var binder = this; binder != null; binder = binder.Next)
+            {
+                if (binder is LoopBinder loopBinder && loopBinder.ScopeDesignator == targetStatement)
+                {
+                    var label = isBreak ? loopBinder.BreakLabel : loopBinder.ContinueLabel;
+                    return isBreak
+                        ? new BoundBreakStatement(node, label)
+                        : (BoundStatement)new BoundContinueStatement(node, label);
+                }
+
+                if (isBreak && binder is SwitchBinder switchBinder && switchBinder.ScopeDesignator == targetStatement)
+                {
+                    return new BoundBreakStatement(node, switchBinder.BreakLabel);
+                }
+            }
+
+            // Should not normally reach here if the containment check passed, but report an error defensively.
+            Error(diagnostics, ErrorCode.ERR_LabeledBreakContinueNotContaining, labelName, labelName.Identifier.ValueText);
+            return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
         }
 
         private static SwitchBinder GetSwitchBinder(Binder binder)

--- a/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
@@ -139,6 +139,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        internal override GeneratedLabelSymbol? GetBreakLabel(string? labelName) => null;
+
+        internal override GeneratedLabelSymbol? GetContinueLabel(string? labelName) => null;
+
         internal override BoundExpression? ConditionalReceiverExpression
         {
             get

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             => _syntax.AwaitKeyword != default;
 
         public ForEachLoopBinder(Binder enclosing, CommonForEachStatementSyntax syntax)
-            : base(enclosing)
+            : base(enclosing, syntax)
         {
             Debug.Assert(syntax != null);
             _syntax = syntax;

--- a/src/Compilers/CSharp/Portable/Binder/ForLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForLoopBinder.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly ForStatementSyntax _syntax;
 
         public ForLoopBinder(Binder enclosing, ForStatementSyntax syntax)
-            : base(enclosing)
+            : base(enclosing, syntax)
         {
             Debug.Assert(syntax != null);
             _syntax = syntax;

--- a/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
@@ -119,6 +119,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        internal override GeneratedLabelSymbol GetBreakLabel(string labelName) => null;
+
+        internal override GeneratedLabelSymbol GetContinueLabel(string labelName) => null;
+
         protected override void ValidateYield(YieldStatementSyntax node, BindingDiagnosticBag diagnostics)
         {
         }

--- a/src/Compilers/CSharp/Portable/Binder/LoopBinderContext.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LoopBinderContext.cs
@@ -14,12 +14,14 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         private readonly GeneratedLabelSymbol _breakLabel;
         private readonly GeneratedLabelSymbol _continueLabel;
+        private readonly string _labelName;
 
-        protected LoopBinder(Binder enclosing)
+        protected LoopBinder(Binder enclosing, SyntaxNode loopSyntax)
             : base(enclosing)
         {
             _breakLabel = new GeneratedLabelSymbol("break");
             _continueLabel = new GeneratedLabelSymbol("continue");
+            _labelName = loopSyntax.Parent is LabeledStatementSyntax labeled ? labeled.Identifier.ValueText : null;
         }
 
         internal override GeneratedLabelSymbol BreakLabel
@@ -37,5 +39,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return _continueLabel;
             }
         }
+
+        internal override GeneratedLabelSymbol GetBreakLabel(string labelName)
+            => (labelName is null || labelName == _labelName) ? _breakLabel : Next.GetBreakLabel(labelName);
+
+        internal override GeneratedLabelSymbol GetContinueLabel(string labelName)
+            => (labelName is null || labelName == _labelName) ? _continueLabel : Next.GetContinueLabel(labelName);
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
@@ -25,11 +25,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         private ImmutableArray<Diagnostic> _switchGoverningDiagnostics;
         private ImmutableArray<AssemblySymbol> _switchGoverningDependencies;
 
+        private readonly string _labelName;
+
         private SwitchBinder(Binder next, SwitchStatementSyntax switchSyntax)
             : base(next)
         {
             SwitchSyntax = switchSyntax;
             _breakLabel = new GeneratedLabelSymbol("break");
+            _labelName = switchSyntax.Parent is LabeledStatementSyntax labeled ? labeled.Identifier.ValueText : null;
         }
 
         protected bool PatternsEnabled =>
@@ -170,6 +173,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return _breakLabel;
             }
         }
+
+        internal override GeneratedLabelSymbol GetBreakLabel(string labelName)
+            => (labelName is null || labelName == _labelName) ? _breakLabel : Next.GetBreakLabel(labelName);
 
         protected override ImmutableArray<LabelSymbol> BuildLabels()
         {

--- a/src/Compilers/CSharp/Portable/Binder/WhileBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WhileBinder.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly StatementSyntax _syntax;
 
         public WhileBinder(Binder enclosing, StatementSyntax syntax)
-            : base(enclosing)
+            : base(enclosing, syntax)
         {
             Debug.Assert(syntax != null && (syntax.IsKind(SyntaxKind.WhileStatement) || syntax.IsKind(SyntaxKind.DoStatement)));
             _syntax = syntax;

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1175,11 +1175,25 @@
   </Node>
 
   <Node Name="BoundBreakStatement" Base="BoundStatement">
+    <!-- The compiler-generated label that the break jumps to (e.g. the loop's "break" label). -->
     <Field Name="Label" Type="LabelSymbol" />
+    <!--
+    For a labeled break (e.g. "break outer;" targeting "outer: while (true) { ... }"), this is the
+    user-declared label symbol for "outer:".  Null for an ordinary unlabeled "break;".  Used by
+    ControlFlowPass to mark the label as referenced, suppressing the WRN_UnreferencedLabel warning.
+    -->
+    <Field Name="SourceLabelOpt" Type="LabelSymbol?" />
   </Node>
 
   <Node Name="BoundContinueStatement" Base="BoundStatement">
+    <!-- The compiler-generated label that the continue jumps to (e.g. the loop's "continue" label). -->
     <Field Name="Label" Type="LabelSymbol" />
+    <!--
+    For a labeled continue (e.g. "continue outer;" targeting "outer: for (...) { ... }"), this is the
+    user-declared label symbol for "outer:".  Null for an ordinary unlabeled "continue;".  Used by
+    ControlFlowPass to mark the label as referenced, suppressing the WRN_UnreferencedLabel warning.
+    -->
+    <Field Name="SourceLabelOpt" Type="LabelSymbol?" />
   </Node>
 
   <Node Name="BoundSwitchStatement" Base="BoundStatement">

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1179,10 +1179,11 @@
     <Field Name="Label" Type="LabelSymbol" />
     <!--
     For a labeled break (e.g. "break outer;" targeting "outer: while (true) { ... }"), this is the
-    user-declared label symbol for "outer:".  Null for an ordinary unlabeled "break;".  Used by
-    ControlFlowPass to mark the label as referenced, suppressing the WRN_UnreferencedLabel warning.
+    bound label expression for "outer".  Null for an ordinary unlabeled "break;".  Used by the
+    SemanticModel to resolve GetSymbolInfo on the label, and by ControlFlowPass (via SourceLabelOpt
+    below) to suppress WRN_UnreferencedLabel.
     -->
-    <Field Name="SourceLabelOpt" Type="LabelSymbol?" />
+    <Field Name="LabelExpressionOpt" Type="BoundLabel?" />
   </Node>
 
   <Node Name="BoundContinueStatement" Base="BoundStatement">
@@ -1190,10 +1191,11 @@
     <Field Name="Label" Type="LabelSymbol" />
     <!--
     For a labeled continue (e.g. "continue outer;" targeting "outer: for (...) { ... }"), this is the
-    user-declared label symbol for "outer:".  Null for an ordinary unlabeled "continue;".  Used by
-    ControlFlowPass to mark the label as referenced, suppressing the WRN_UnreferencedLabel warning.
+    bound label expression for "outer".  Null for an ordinary unlabeled "continue;".  Used by the
+    SemanticModel to resolve GetSymbolInfo on the label, and by ControlFlowPass (via LabelExpressionOpt's
+    Label) to suppress WRN_UnreferencedLabel.
     -->
-    <Field Name="SourceLabelOpt" Type="LabelSymbol?" />
+    <Field Name="LabelExpressionOpt" Type="BoundLabel?" />
   </Node>
 
   <Node Name="BoundSwitchStatement" Base="BoundStatement">

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -8090,6 +8090,18 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureUserDefinedCompoundAssignmentOperators" xml:space="preserve">
     <value>user-defined compound assignment operators</value>
   </data>
+  <data name="IDS_FeatureLabeledBreakContinue" xml:space="preserve">
+    <value>labeled break and continue</value>
+  </data>
+  <data name="ERR_LabeledBreakContinueNotOnLoopOrSwitch" xml:space="preserve">
+    <value>The label '{0}' does not refer to a containing loop or switch statement</value>
+  </data>
+  <data name="ERR_LabeledContinueNotOnLoop" xml:space="preserve">
+    <value>The label '{0}' does not refer to a containing loop statement</value>
+  </data>
+  <data name="ERR_LabeledBreakContinueNotContaining" xml:space="preserve">
+    <value>The label '{0}' does not refer to a statement that contains this break or continue statement</value>
+  </data>
   <data name="ERR_OperatorsMustBePublic" xml:space="preserve">
     <value>User-defined operator '{0}' must be declared public</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -759,6 +759,9 @@
   <data name="ERR_NoBreakOrCont" xml:space="preserve">
     <value>No enclosing loop out of which to break or continue</value>
   </data>
+  <data name="ERR_NoBreakOrContId" xml:space="preserve">
+    <value>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</value>
+  </data>
   <data name="ERR_DuplicateLabel" xml:space="preserve">
     <value>The label '{0}' is a duplicate</value>
   </data>
@@ -8092,15 +8095,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="IDS_FeatureLabeledBreakContinue" xml:space="preserve">
     <value>labeled break and continue</value>
-  </data>
-  <data name="ERR_LabeledBreakContinueNotOnLoopOrSwitch" xml:space="preserve">
-    <value>The label '{0}' does not refer to a containing loop or switch statement</value>
-  </data>
-  <data name="ERR_LabeledContinueNotOnLoop" xml:space="preserve">
-    <value>The label '{0}' does not refer to a containing loop statement</value>
-  </data>
-  <data name="ERR_LabeledBreakContinueNotContaining" xml:space="preserve">
-    <value>The label '{0}' does not refer to a statement that contains this break or continue statement</value>
   </data>
   <data name="ERR_OperatorsMustBePublic" xml:space="preserve">
     <value>User-defined operator '{0}' must be declared public</value>

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -2195,6 +2195,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             case BaseExpressionColonSyntax:
                             case NameEqualsSyntax:
                             case GotoStatementSyntax { RawKind: (int)SyntaxKind.GotoStatement }:
+                            case BreakStatementSyntax { Name: not null }:
+                            case ContinueStatementSyntax { Name: not null }:
                             case TypeParameterConstraintClauseSyntax:
                             case AliasQualifiedNameSyntax:
                                 // These nodes do not have anything interesting for us

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2484,9 +2484,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_UnsafeConstructorConstraint = 9376,
         WRN_UnsafeMeaningless = 9377,
 
-        ERR_LabeledBreakContinueNotOnLoopOrSwitch = 9378,
-        ERR_LabeledContinueNotOnLoop = 9379,
-        ERR_LabeledBreakContinueNotContaining = 9380,
+        ERR_NoBreakOrContId = 9378,
 
         // Note: you will need to do the following after adding errors:
         //  1) Update ErrorFacts.IsBuildOnlyDiagnostic (src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs)

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2484,6 +2484,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_UnsafeConstructorConstraint = 9376,
         WRN_UnsafeMeaningless = 9377,
 
+        ERR_LabeledBreakContinueNotOnLoopOrSwitch = 9378,
+        ERR_LabeledContinueNotOnLoop = 9379,
+        ERR_LabeledBreakContinueNotContaining = 9380,
+
         // Note: you will need to do the following after adding errors:
         //  1) Update ErrorFacts.IsBuildOnlyDiagnostic (src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs)
         //  2) Add message to CSharpResources.resx

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -2589,6 +2589,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 or ErrorCode.ERR_UnionConstructorCallsDefaultConstructor
                 or ErrorCode.ERR_UnsafeConstructorConstraint
                 or ErrorCode.WRN_UnsafeMeaningless
+                or ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch
+                or ErrorCode.ERR_LabeledContinueNotOnLoop
+                or ErrorCode.ERR_LabeledBreakContinueNotContaining
                     => false,
             };
 #pragma warning restore CS8524 // The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value.

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -2589,9 +2589,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 or ErrorCode.ERR_UnionConstructorCallsDefaultConstructor
                 or ErrorCode.ERR_UnsafeConstructorConstraint
                 or ErrorCode.WRN_UnsafeMeaningless
-                or ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch
-                or ErrorCode.ERR_LabeledContinueNotOnLoop
-                or ErrorCode.ERR_LabeledBreakContinueNotContaining
+                or ErrorCode.ERR_NoBreakOrContId
                     => false,
             };
 #pragma warning restore CS8524 // The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value.

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -310,6 +310,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureUnsafeEvolution = MessageBase + 12859,
 
         IDS_FeatureUnions = MessageBase + 12860,
+
+        IDS_FeatureLabeledBreakContinue = MessageBase + 12861,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -505,6 +507,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_FeatureNullConditionalAssignment:
                 case MessageID.IDS_FeatureExpressionOptionalAndNamedArguments:
                 case MessageID.IDS_FeatureUserDefinedCompoundAssignmentOperators:
+                case MessageID.IDS_FeatureLabeledBreakContinue:
                     return LanguageVersion.CSharp14;
 
                 // C# 13.0 features.

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -495,6 +495,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_FeatureCollectionExpressionArguments:
                 case MessageID.IDS_FeatureUnsafeEvolution: // https://github.com/dotnet/roslyn/issues/82546: keep this in preview until C# 16
                 case MessageID.IDS_FeatureUnions:
+                case MessageID.IDS_FeatureLabeledBreakContinue:
                     return LanguageVersion.Preview;
 
                 // C# 14.0 features.
@@ -507,7 +508,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_FeatureNullConditionalAssignment:
                 case MessageID.IDS_FeatureExpressionOptionalAndNamedArguments:
                 case MessageID.IDS_FeatureUserDefinedCompoundAssignmentOperators:
-                case MessageID.IDS_FeatureLabeledBreakContinue:
                     return LanguageVersion.CSharp14;
 
                 // C# 13.0 features.

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
@@ -371,16 +371,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitBreakStatement(BoundBreakStatement node)
         {
-            if (node.SourceLabelOpt != null)
-                _labelsUsed.Add(node.SourceLabelOpt);
+            if (node.LabelExpressionOpt != null)
+                _labelsUsed.Add(node.LabelExpressionOpt.Label);
 
             return base.VisitBreakStatement(node);
         }
 
         public override BoundNode VisitContinueStatement(BoundContinueStatement node)
         {
-            if (node.SourceLabelOpt != null)
-                _labelsUsed.Add(node.SourceLabelOpt);
+            if (node.LabelExpressionOpt != null)
+                _labelsUsed.Add(node.LabelExpressionOpt.Label);
 
             return base.VisitContinueStatement(node);
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
@@ -369,6 +369,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             return base.VisitGotoStatement(node);
         }
 
+        public override BoundNode VisitBreakStatement(BoundBreakStatement node)
+        {
+            if (node.SourceLabelOpt != null)
+                _labelsUsed.Add(node.SourceLabelOpt);
+
+            return base.VisitBreakStatement(node);
+        }
+
+        public override BoundNode VisitContinueStatement(BoundContinueStatement node)
+        {
+            if (node.SourceLabelOpt != null)
+                _labelsUsed.Add(node.SourceLabelOpt);
+
+            return base.VisitContinueStatement(node);
+        }
+
         protected override void VisitSwitchSection(BoundSwitchSection node, bool isLastSection)
         {
             base.VisitSwitchSection(node, isLastSection);

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -3753,34 +3753,37 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundBreakStatement : BoundStatement
     {
-        public BoundBreakStatement(SyntaxNode syntax, LabelSymbol label, bool hasErrors)
+        public BoundBreakStatement(SyntaxNode syntax, LabelSymbol label, LabelSymbol? sourceLabelOpt, bool hasErrors)
             : base(BoundKind.BreakStatement, syntax, hasErrors)
         {
 
             RoslynDebug.Assert(label is object, "Field 'label' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
             this.Label = label;
+            this.SourceLabelOpt = sourceLabelOpt;
         }
 
-        public BoundBreakStatement(SyntaxNode syntax, LabelSymbol label)
+        public BoundBreakStatement(SyntaxNode syntax, LabelSymbol label, LabelSymbol? sourceLabelOpt)
             : base(BoundKind.BreakStatement, syntax)
         {
 
             RoslynDebug.Assert(label is object, "Field 'label' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
             this.Label = label;
+            this.SourceLabelOpt = sourceLabelOpt;
         }
 
         public LabelSymbol Label { get; }
+        public LabelSymbol? SourceLabelOpt { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitBreakStatement(this);
 
-        public BoundBreakStatement Update(LabelSymbol label)
+        public BoundBreakStatement Update(LabelSymbol label, LabelSymbol? sourceLabelOpt)
         {
-            if (!Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(label, this.Label))
+            if (!Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(label, this.Label) || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(sourceLabelOpt, this.SourceLabelOpt))
             {
-                var result = new BoundBreakStatement(this.Syntax, label, this.HasErrors);
+                var result = new BoundBreakStatement(this.Syntax, label, sourceLabelOpt, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -3790,34 +3793,37 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundContinueStatement : BoundStatement
     {
-        public BoundContinueStatement(SyntaxNode syntax, LabelSymbol label, bool hasErrors)
+        public BoundContinueStatement(SyntaxNode syntax, LabelSymbol label, LabelSymbol? sourceLabelOpt, bool hasErrors)
             : base(BoundKind.ContinueStatement, syntax, hasErrors)
         {
 
             RoslynDebug.Assert(label is object, "Field 'label' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
             this.Label = label;
+            this.SourceLabelOpt = sourceLabelOpt;
         }
 
-        public BoundContinueStatement(SyntaxNode syntax, LabelSymbol label)
+        public BoundContinueStatement(SyntaxNode syntax, LabelSymbol label, LabelSymbol? sourceLabelOpt)
             : base(BoundKind.ContinueStatement, syntax)
         {
 
             RoslynDebug.Assert(label is object, "Field 'label' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
             this.Label = label;
+            this.SourceLabelOpt = sourceLabelOpt;
         }
 
         public LabelSymbol Label { get; }
+        public LabelSymbol? SourceLabelOpt { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitContinueStatement(this);
 
-        public BoundContinueStatement Update(LabelSymbol label)
+        public BoundContinueStatement Update(LabelSymbol label, LabelSymbol? sourceLabelOpt)
         {
-            if (!Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(label, this.Label))
+            if (!Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(label, this.Label) || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(sourceLabelOpt, this.SourceLabelOpt))
             {
-                var result = new BoundContinueStatement(this.Syntax, label, this.HasErrors);
+                var result = new BoundContinueStatement(this.Syntax, label, sourceLabelOpt, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -11711,12 +11717,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitBreakStatement(BoundBreakStatement node)
         {
             LabelSymbol label = this.VisitLabelSymbol(node.Label);
-            return node.Update(label);
+            LabelSymbol? sourceLabelOpt = this.VisitLabelSymbol(node.SourceLabelOpt);
+            return node.Update(label, sourceLabelOpt);
         }
         public override BoundNode? VisitContinueStatement(BoundContinueStatement node)
         {
             LabelSymbol label = this.VisitLabelSymbol(node.Label);
-            return node.Update(label);
+            LabelSymbol? sourceLabelOpt = this.VisitLabelSymbol(node.SourceLabelOpt);
+            return node.Update(label, sourceLabelOpt);
         }
         public override BoundNode? VisitSwitchStatement(BoundSwitchStatement node)
         {
@@ -16321,12 +16329,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override TreeDumperNode VisitBreakStatement(BoundBreakStatement node, object? arg) => new TreeDumperNode("breakStatement", null, new TreeDumperNode[]
         {
             new TreeDumperNode("label", node.Label, null),
+            new TreeDumperNode("sourceLabelOpt", node.SourceLabelOpt, null),
             new TreeDumperNode("hasErrors", node.HasErrors, null)
         }
         );
         public override TreeDumperNode VisitContinueStatement(BoundContinueStatement node, object? arg) => new TreeDumperNode("continueStatement", null, new TreeDumperNode[]
         {
             new TreeDumperNode("label", node.Label, null),
+            new TreeDumperNode("sourceLabelOpt", node.SourceLabelOpt, null),
             new TreeDumperNode("hasErrors", node.HasErrors, null)
         }
         );

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -3753,37 +3753,27 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundBreakStatement : BoundStatement
     {
-        public BoundBreakStatement(SyntaxNode syntax, LabelSymbol label, LabelSymbol? sourceLabelOpt, bool hasErrors)
-            : base(BoundKind.BreakStatement, syntax, hasErrors)
+        public BoundBreakStatement(SyntaxNode syntax, LabelSymbol label, BoundLabel? labelExpressionOpt, bool hasErrors = false)
+            : base(BoundKind.BreakStatement, syntax, hasErrors || labelExpressionOpt.HasErrors())
         {
 
             RoslynDebug.Assert(label is object, "Field 'label' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
             this.Label = label;
-            this.SourceLabelOpt = sourceLabelOpt;
-        }
-
-        public BoundBreakStatement(SyntaxNode syntax, LabelSymbol label, LabelSymbol? sourceLabelOpt)
-            : base(BoundKind.BreakStatement, syntax)
-        {
-
-            RoslynDebug.Assert(label is object, "Field 'label' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
-
-            this.Label = label;
-            this.SourceLabelOpt = sourceLabelOpt;
+            this.LabelExpressionOpt = labelExpressionOpt;
         }
 
         public LabelSymbol Label { get; }
-        public LabelSymbol? SourceLabelOpt { get; }
+        public BoundLabel? LabelExpressionOpt { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitBreakStatement(this);
 
-        public BoundBreakStatement Update(LabelSymbol label, LabelSymbol? sourceLabelOpt)
+        public BoundBreakStatement Update(LabelSymbol label, BoundLabel? labelExpressionOpt)
         {
-            if (!Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(label, this.Label) || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(sourceLabelOpt, this.SourceLabelOpt))
+            if (!Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(label, this.Label) || labelExpressionOpt != this.LabelExpressionOpt)
             {
-                var result = new BoundBreakStatement(this.Syntax, label, sourceLabelOpt, this.HasErrors);
+                var result = new BoundBreakStatement(this.Syntax, label, labelExpressionOpt, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -3793,37 +3783,27 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundContinueStatement : BoundStatement
     {
-        public BoundContinueStatement(SyntaxNode syntax, LabelSymbol label, LabelSymbol? sourceLabelOpt, bool hasErrors)
-            : base(BoundKind.ContinueStatement, syntax, hasErrors)
+        public BoundContinueStatement(SyntaxNode syntax, LabelSymbol label, BoundLabel? labelExpressionOpt, bool hasErrors = false)
+            : base(BoundKind.ContinueStatement, syntax, hasErrors || labelExpressionOpt.HasErrors())
         {
 
             RoslynDebug.Assert(label is object, "Field 'label' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
             this.Label = label;
-            this.SourceLabelOpt = sourceLabelOpt;
-        }
-
-        public BoundContinueStatement(SyntaxNode syntax, LabelSymbol label, LabelSymbol? sourceLabelOpt)
-            : base(BoundKind.ContinueStatement, syntax)
-        {
-
-            RoslynDebug.Assert(label is object, "Field 'label' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
-
-            this.Label = label;
-            this.SourceLabelOpt = sourceLabelOpt;
+            this.LabelExpressionOpt = labelExpressionOpt;
         }
 
         public LabelSymbol Label { get; }
-        public LabelSymbol? SourceLabelOpt { get; }
+        public BoundLabel? LabelExpressionOpt { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitContinueStatement(this);
 
-        public BoundContinueStatement Update(LabelSymbol label, LabelSymbol? sourceLabelOpt)
+        public BoundContinueStatement Update(LabelSymbol label, BoundLabel? labelExpressionOpt)
         {
-            if (!Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(label, this.Label) || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(sourceLabelOpt, this.SourceLabelOpt))
+            if (!Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(label, this.Label) || labelExpressionOpt != this.LabelExpressionOpt)
             {
-                var result = new BoundContinueStatement(this.Syntax, label, sourceLabelOpt, this.HasErrors);
+                var result = new BoundContinueStatement(this.Syntax, label, labelExpressionOpt, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -10426,8 +10406,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.Visit(node.Expression);
             return null;
         }
-        public override BoundNode? VisitBreakStatement(BoundBreakStatement node) => null;
-        public override BoundNode? VisitContinueStatement(BoundContinueStatement node) => null;
+        public override BoundNode? VisitBreakStatement(BoundBreakStatement node)
+        {
+            this.Visit(node.LabelExpressionOpt);
+            return null;
+        }
+        public override BoundNode? VisitContinueStatement(BoundContinueStatement node)
+        {
+            this.Visit(node.LabelExpressionOpt);
+            return null;
+        }
         public override BoundNode? VisitSwitchStatement(BoundSwitchStatement node)
         {
             this.Visit(node.Expression);
@@ -11717,14 +11705,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitBreakStatement(BoundBreakStatement node)
         {
             LabelSymbol label = this.VisitLabelSymbol(node.Label);
-            LabelSymbol? sourceLabelOpt = this.VisitLabelSymbol(node.SourceLabelOpt);
-            return node.Update(label, sourceLabelOpt);
+            BoundLabel? labelExpressionOpt = (BoundLabel?)this.Visit(node.LabelExpressionOpt);
+            return node.Update(label, labelExpressionOpt);
         }
         public override BoundNode? VisitContinueStatement(BoundContinueStatement node)
         {
             LabelSymbol label = this.VisitLabelSymbol(node.Label);
-            LabelSymbol? sourceLabelOpt = this.VisitLabelSymbol(node.SourceLabelOpt);
-            return node.Update(label, sourceLabelOpt);
+            BoundLabel? labelExpressionOpt = (BoundLabel?)this.Visit(node.LabelExpressionOpt);
+            return node.Update(label, labelExpressionOpt);
         }
         public override BoundNode? VisitSwitchStatement(BoundSwitchStatement node)
         {
@@ -16329,14 +16317,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override TreeDumperNode VisitBreakStatement(BoundBreakStatement node, object? arg) => new TreeDumperNode("breakStatement", null, new TreeDumperNode[]
         {
             new TreeDumperNode("label", node.Label, null),
-            new TreeDumperNode("sourceLabelOpt", node.SourceLabelOpt, null),
+            new TreeDumperNode("labelExpressionOpt", null, new TreeDumperNode[] { Visit(node.LabelExpressionOpt, null) }),
             new TreeDumperNode("hasErrors", node.HasErrors, null)
         }
         );
         public override TreeDumperNode VisitContinueStatement(BoundContinueStatement node, object? arg) => new TreeDumperNode("continueStatement", null, new TreeDumperNode[]
         {
             new TreeDumperNode("label", node.Label, null),
-            new TreeDumperNode("sourceLabelOpt", node.SourceLabelOpt, null),
+            new TreeDumperNode("labelExpressionOpt", null, new TreeDumperNode[] { Visit(node.LabelExpressionOpt, null) }),
             new TreeDumperNode("hasErrors", node.HasErrors, null)
         }
         );

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Internal.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Internal.Generated.cs
@@ -11479,12 +11479,13 @@ internal sealed partial class BreakStatementSyntax : StatementSyntax
 {
     internal readonly GreenNode? attributeLists;
     internal readonly SyntaxToken breakKeyword;
+    internal readonly IdentifierNameSyntax? name;
     internal readonly SyntaxToken semicolonToken;
 
-    internal BreakStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken breakKeyword, SyntaxToken semicolonToken, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
+    internal BreakStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken breakKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
       : base(kind, diagnostics, annotations)
     {
-        this.SlotCount = 3;
+        this.SlotCount = 4;
         if (attributeLists != null)
         {
             this.AdjustFlagsAndWidth(attributeLists);
@@ -11492,15 +11493,20 @@ internal sealed partial class BreakStatementSyntax : StatementSyntax
         }
         this.AdjustFlagsAndWidth(breakKeyword);
         this.breakKeyword = breakKeyword;
+        if (name != null)
+        {
+            this.AdjustFlagsAndWidth(name);
+            this.name = name;
+        }
         this.AdjustFlagsAndWidth(semicolonToken);
         this.semicolonToken = semicolonToken;
     }
 
-    internal BreakStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken breakKeyword, SyntaxToken semicolonToken, SyntaxFactoryContext context)
+    internal BreakStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken breakKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken, SyntaxFactoryContext context)
       : base(kind)
     {
         this.SetFactoryContext(context);
-        this.SlotCount = 3;
+        this.SlotCount = 4;
         if (attributeLists != null)
         {
             this.AdjustFlagsAndWidth(attributeLists);
@@ -11508,14 +11514,19 @@ internal sealed partial class BreakStatementSyntax : StatementSyntax
         }
         this.AdjustFlagsAndWidth(breakKeyword);
         this.breakKeyword = breakKeyword;
+        if (name != null)
+        {
+            this.AdjustFlagsAndWidth(name);
+            this.name = name;
+        }
         this.AdjustFlagsAndWidth(semicolonToken);
         this.semicolonToken = semicolonToken;
     }
 
-    internal BreakStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken breakKeyword, SyntaxToken semicolonToken)
+    internal BreakStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken breakKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken)
       : base(kind)
     {
-        this.SlotCount = 3;
+        this.SlotCount = 4;
         if (attributeLists != null)
         {
             this.AdjustFlagsAndWidth(attributeLists);
@@ -11523,12 +11534,18 @@ internal sealed partial class BreakStatementSyntax : StatementSyntax
         }
         this.AdjustFlagsAndWidth(breakKeyword);
         this.breakKeyword = breakKeyword;
+        if (name != null)
+        {
+            this.AdjustFlagsAndWidth(name);
+            this.name = name;
+        }
         this.AdjustFlagsAndWidth(semicolonToken);
         this.semicolonToken = semicolonToken;
     }
 
     public override CoreSyntax.SyntaxList<AttributeListSyntax> AttributeLists => new CoreSyntax.SyntaxList<AttributeListSyntax>(this.attributeLists);
     public SyntaxToken BreakKeyword => this.breakKeyword;
+    public IdentifierNameSyntax? Name => this.name;
     public SyntaxToken SemicolonToken => this.semicolonToken;
 
     internal override GreenNode? GetSlot(int index)
@@ -11536,7 +11553,8 @@ internal sealed partial class BreakStatementSyntax : StatementSyntax
         {
             0 => this.attributeLists,
             1 => this.breakKeyword,
-            2 => this.semicolonToken,
+            2 => this.name,
+            3 => this.semicolonToken,
             _ => null,
         };
 
@@ -11545,11 +11563,11 @@ internal sealed partial class BreakStatementSyntax : StatementSyntax
     public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitBreakStatement(this);
     public override TResult Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) => visitor.VisitBreakStatement(this);
 
-    public BreakStatementSyntax Update(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken breakKeyword, SyntaxToken semicolonToken)
+    public BreakStatementSyntax Update(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken breakKeyword, IdentifierNameSyntax name, SyntaxToken semicolonToken)
     {
-        if (attributeLists != this.AttributeLists || breakKeyword != this.BreakKeyword || semicolonToken != this.SemicolonToken)
+        if (attributeLists != this.AttributeLists || breakKeyword != this.BreakKeyword || name != this.Name || semicolonToken != this.SemicolonToken)
         {
-            var newNode = SyntaxFactory.BreakStatement(attributeLists, breakKeyword, semicolonToken);
+            var newNode = SyntaxFactory.BreakStatement(attributeLists, breakKeyword, name, semicolonToken);
             var diags = GetDiagnostics();
             if (diags?.Length > 0)
                 newNode = newNode.WithDiagnosticsGreen(diags);
@@ -11563,22 +11581,23 @@ internal sealed partial class BreakStatementSyntax : StatementSyntax
     }
 
     internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
-        => new BreakStatementSyntax(this.Kind, this.attributeLists, this.breakKeyword, this.semicolonToken, diagnostics, GetAnnotations());
+        => new BreakStatementSyntax(this.Kind, this.attributeLists, this.breakKeyword, this.name, this.semicolonToken, diagnostics, GetAnnotations());
 
     internal override GreenNode SetAnnotations(SyntaxAnnotation[]? annotations)
-        => new BreakStatementSyntax(this.Kind, this.attributeLists, this.breakKeyword, this.semicolonToken, GetDiagnostics(), annotations);
+        => new BreakStatementSyntax(this.Kind, this.attributeLists, this.breakKeyword, this.name, this.semicolonToken, GetDiagnostics(), annotations);
 }
 
 internal sealed partial class ContinueStatementSyntax : StatementSyntax
 {
     internal readonly GreenNode? attributeLists;
     internal readonly SyntaxToken continueKeyword;
+    internal readonly IdentifierNameSyntax? name;
     internal readonly SyntaxToken semicolonToken;
 
-    internal ContinueStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken continueKeyword, SyntaxToken semicolonToken, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
+    internal ContinueStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken continueKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
       : base(kind, diagnostics, annotations)
     {
-        this.SlotCount = 3;
+        this.SlotCount = 4;
         if (attributeLists != null)
         {
             this.AdjustFlagsAndWidth(attributeLists);
@@ -11586,15 +11605,20 @@ internal sealed partial class ContinueStatementSyntax : StatementSyntax
         }
         this.AdjustFlagsAndWidth(continueKeyword);
         this.continueKeyword = continueKeyword;
+        if (name != null)
+        {
+            this.AdjustFlagsAndWidth(name);
+            this.name = name;
+        }
         this.AdjustFlagsAndWidth(semicolonToken);
         this.semicolonToken = semicolonToken;
     }
 
-    internal ContinueStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken continueKeyword, SyntaxToken semicolonToken, SyntaxFactoryContext context)
+    internal ContinueStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken continueKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken, SyntaxFactoryContext context)
       : base(kind)
     {
         this.SetFactoryContext(context);
-        this.SlotCount = 3;
+        this.SlotCount = 4;
         if (attributeLists != null)
         {
             this.AdjustFlagsAndWidth(attributeLists);
@@ -11602,14 +11626,19 @@ internal sealed partial class ContinueStatementSyntax : StatementSyntax
         }
         this.AdjustFlagsAndWidth(continueKeyword);
         this.continueKeyword = continueKeyword;
+        if (name != null)
+        {
+            this.AdjustFlagsAndWidth(name);
+            this.name = name;
+        }
         this.AdjustFlagsAndWidth(semicolonToken);
         this.semicolonToken = semicolonToken;
     }
 
-    internal ContinueStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken continueKeyword, SyntaxToken semicolonToken)
+    internal ContinueStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken continueKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken)
       : base(kind)
     {
-        this.SlotCount = 3;
+        this.SlotCount = 4;
         if (attributeLists != null)
         {
             this.AdjustFlagsAndWidth(attributeLists);
@@ -11617,12 +11646,18 @@ internal sealed partial class ContinueStatementSyntax : StatementSyntax
         }
         this.AdjustFlagsAndWidth(continueKeyword);
         this.continueKeyword = continueKeyword;
+        if (name != null)
+        {
+            this.AdjustFlagsAndWidth(name);
+            this.name = name;
+        }
         this.AdjustFlagsAndWidth(semicolonToken);
         this.semicolonToken = semicolonToken;
     }
 
     public override CoreSyntax.SyntaxList<AttributeListSyntax> AttributeLists => new CoreSyntax.SyntaxList<AttributeListSyntax>(this.attributeLists);
     public SyntaxToken ContinueKeyword => this.continueKeyword;
+    public IdentifierNameSyntax? Name => this.name;
     public SyntaxToken SemicolonToken => this.semicolonToken;
 
     internal override GreenNode? GetSlot(int index)
@@ -11630,7 +11665,8 @@ internal sealed partial class ContinueStatementSyntax : StatementSyntax
         {
             0 => this.attributeLists,
             1 => this.continueKeyword,
-            2 => this.semicolonToken,
+            2 => this.name,
+            3 => this.semicolonToken,
             _ => null,
         };
 
@@ -11639,11 +11675,11 @@ internal sealed partial class ContinueStatementSyntax : StatementSyntax
     public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitContinueStatement(this);
     public override TResult Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) => visitor.VisitContinueStatement(this);
 
-    public ContinueStatementSyntax Update(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken continueKeyword, SyntaxToken semicolonToken)
+    public ContinueStatementSyntax Update(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken continueKeyword, IdentifierNameSyntax name, SyntaxToken semicolonToken)
     {
-        if (attributeLists != this.AttributeLists || continueKeyword != this.ContinueKeyword || semicolonToken != this.SemicolonToken)
+        if (attributeLists != this.AttributeLists || continueKeyword != this.ContinueKeyword || name != this.Name || semicolonToken != this.SemicolonToken)
         {
-            var newNode = SyntaxFactory.ContinueStatement(attributeLists, continueKeyword, semicolonToken);
+            var newNode = SyntaxFactory.ContinueStatement(attributeLists, continueKeyword, name, semicolonToken);
             var diags = GetDiagnostics();
             if (diags?.Length > 0)
                 newNode = newNode.WithDiagnosticsGreen(diags);
@@ -11657,10 +11693,10 @@ internal sealed partial class ContinueStatementSyntax : StatementSyntax
     }
 
     internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
-        => new ContinueStatementSyntax(this.Kind, this.attributeLists, this.continueKeyword, this.semicolonToken, diagnostics, GetAnnotations());
+        => new ContinueStatementSyntax(this.Kind, this.attributeLists, this.continueKeyword, this.name, this.semicolonToken, diagnostics, GetAnnotations());
 
     internal override GreenNode SetAnnotations(SyntaxAnnotation[]? annotations)
-        => new ContinueStatementSyntax(this.Kind, this.attributeLists, this.continueKeyword, this.semicolonToken, GetDiagnostics(), annotations);
+        => new ContinueStatementSyntax(this.Kind, this.attributeLists, this.continueKeyword, this.name, this.semicolonToken, GetDiagnostics(), annotations);
 }
 
 internal sealed partial class ReturnStatementSyntax : StatementSyntax
@@ -27891,10 +27927,10 @@ internal partial class CSharpSyntaxRewriter : CSharpSyntaxVisitor<CSharpSyntaxNo
         => node.Update(VisitList(node.AttributeLists), (SyntaxToken)Visit(node.GotoKeyword), (SyntaxToken)Visit(node.CaseOrDefaultKeyword), (ExpressionSyntax)Visit(node.Expression), (SyntaxToken)Visit(node.SemicolonToken));
 
     public override CSharpSyntaxNode VisitBreakStatement(BreakStatementSyntax node)
-        => node.Update(VisitList(node.AttributeLists), (SyntaxToken)Visit(node.BreakKeyword), (SyntaxToken)Visit(node.SemicolonToken));
+        => node.Update(VisitList(node.AttributeLists), (SyntaxToken)Visit(node.BreakKeyword), (IdentifierNameSyntax)Visit(node.Name), (SyntaxToken)Visit(node.SemicolonToken));
 
     public override CSharpSyntaxNode VisitContinueStatement(ContinueStatementSyntax node)
-        => node.Update(VisitList(node.AttributeLists), (SyntaxToken)Visit(node.ContinueKeyword), (SyntaxToken)Visit(node.SemicolonToken));
+        => node.Update(VisitList(node.AttributeLists), (SyntaxToken)Visit(node.ContinueKeyword), (IdentifierNameSyntax)Visit(node.Name), (SyntaxToken)Visit(node.SemicolonToken));
 
     public override CSharpSyntaxNode VisitReturnStatement(ReturnStatementSyntax node)
         => node.Update(VisitList(node.AttributeLists), (SyntaxToken)Visit(node.ReturnKeyword), (ExpressionSyntax)Visit(node.Expression), (SyntaxToken)Visit(node.SemicolonToken));
@@ -30933,7 +30969,7 @@ internal partial class ContextAwareSyntax
         return new GotoStatementSyntax(kind, attributeLists.Node, gotoKeyword, caseOrDefaultKeyword, expression, semicolonToken, this.context);
     }
 
-    public BreakStatementSyntax BreakStatement(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken breakKeyword, SyntaxToken semicolonToken)
+    public BreakStatementSyntax BreakStatement(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken breakKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken)
     {
 #if DEBUG
         if (breakKeyword == null) throw new ArgumentNullException(nameof(breakKeyword));
@@ -30942,20 +30978,10 @@ internal partial class ContextAwareSyntax
         if (semicolonToken.Kind != SyntaxKind.SemicolonToken) throw new ArgumentException(nameof(semicolonToken));
 #endif
 
-        int hash;
-        var cached = CSharpSyntaxNodeCache.TryGetNode((int)SyntaxKind.BreakStatement, attributeLists.Node, breakKeyword, semicolonToken, this.context, out hash);
-        if (cached != null) return (BreakStatementSyntax)cached;
-
-        var result = new BreakStatementSyntax(SyntaxKind.BreakStatement, attributeLists.Node, breakKeyword, semicolonToken, this.context);
-        if (hash >= 0)
-        {
-            SyntaxNodeCache.AddNode(result, hash);
-        }
-
-        return result;
+        return new BreakStatementSyntax(SyntaxKind.BreakStatement, attributeLists.Node, breakKeyword, name, semicolonToken, this.context);
     }
 
-    public ContinueStatementSyntax ContinueStatement(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken continueKeyword, SyntaxToken semicolonToken)
+    public ContinueStatementSyntax ContinueStatement(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken continueKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken)
     {
 #if DEBUG
         if (continueKeyword == null) throw new ArgumentNullException(nameof(continueKeyword));
@@ -30964,17 +30990,7 @@ internal partial class ContextAwareSyntax
         if (semicolonToken.Kind != SyntaxKind.SemicolonToken) throw new ArgumentException(nameof(semicolonToken));
 #endif
 
-        int hash;
-        var cached = CSharpSyntaxNodeCache.TryGetNode((int)SyntaxKind.ContinueStatement, attributeLists.Node, continueKeyword, semicolonToken, this.context, out hash);
-        if (cached != null) return (ContinueStatementSyntax)cached;
-
-        var result = new ContinueStatementSyntax(SyntaxKind.ContinueStatement, attributeLists.Node, continueKeyword, semicolonToken, this.context);
-        if (hash >= 0)
-        {
-            SyntaxNodeCache.AddNode(result, hash);
-        }
-
-        return result;
+        return new ContinueStatementSyntax(SyntaxKind.ContinueStatement, attributeLists.Node, continueKeyword, name, semicolonToken, this.context);
     }
 
     public ReturnStatementSyntax ReturnStatement(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken returnKeyword, ExpressionSyntax? expression, SyntaxToken semicolonToken)
@@ -36332,7 +36348,7 @@ internal static partial class SyntaxFactory
         return new GotoStatementSyntax(kind, attributeLists.Node, gotoKeyword, caseOrDefaultKeyword, expression, semicolonToken);
     }
 
-    public static BreakStatementSyntax BreakStatement(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken breakKeyword, SyntaxToken semicolonToken)
+    public static BreakStatementSyntax BreakStatement(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken breakKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken)
     {
 #if DEBUG
         if (breakKeyword == null) throw new ArgumentNullException(nameof(breakKeyword));
@@ -36341,20 +36357,10 @@ internal static partial class SyntaxFactory
         if (semicolonToken.Kind != SyntaxKind.SemicolonToken) throw new ArgumentException(nameof(semicolonToken));
 #endif
 
-        int hash;
-        var cached = SyntaxNodeCache.TryGetNode((int)SyntaxKind.BreakStatement, attributeLists.Node, breakKeyword, semicolonToken, out hash);
-        if (cached != null) return (BreakStatementSyntax)cached;
-
-        var result = new BreakStatementSyntax(SyntaxKind.BreakStatement, attributeLists.Node, breakKeyword, semicolonToken);
-        if (hash >= 0)
-        {
-            SyntaxNodeCache.AddNode(result, hash);
-        }
-
-        return result;
+        return new BreakStatementSyntax(SyntaxKind.BreakStatement, attributeLists.Node, breakKeyword, name, semicolonToken);
     }
 
-    public static ContinueStatementSyntax ContinueStatement(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken continueKeyword, SyntaxToken semicolonToken)
+    public static ContinueStatementSyntax ContinueStatement(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken continueKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken)
     {
 #if DEBUG
         if (continueKeyword == null) throw new ArgumentNullException(nameof(continueKeyword));
@@ -36363,17 +36369,7 @@ internal static partial class SyntaxFactory
         if (semicolonToken.Kind != SyntaxKind.SemicolonToken) throw new ArgumentException(nameof(semicolonToken));
 #endif
 
-        int hash;
-        var cached = SyntaxNodeCache.TryGetNode((int)SyntaxKind.ContinueStatement, attributeLists.Node, continueKeyword, semicolonToken, out hash);
-        if (cached != null) return (ContinueStatementSyntax)cached;
-
-        var result = new ContinueStatementSyntax(SyntaxKind.ContinueStatement, attributeLists.Node, continueKeyword, semicolonToken);
-        if (hash >= 0)
-        {
-            SyntaxNodeCache.AddNode(result, hash);
-        }
-
-        return result;
+        return new ContinueStatementSyntax(SyntaxKind.ContinueStatement, attributeLists.Node, continueKeyword, name, semicolonToken);
     }
 
     public static ReturnStatementSyntax ReturnStatement(CoreSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken returnKeyword, ExpressionSyntax? expression, SyntaxToken semicolonToken)

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Main.Generated.cs
@@ -1879,10 +1879,10 @@ public partial class CSharpSyntaxRewriter : CSharpSyntaxVisitor<SyntaxNode?>
         => node.Update(VisitList(node.AttributeLists), VisitToken(node.GotoKeyword), VisitToken(node.CaseOrDefaultKeyword), (ExpressionSyntax?)Visit(node.Expression), VisitToken(node.SemicolonToken));
 
     public override SyntaxNode? VisitBreakStatement(BreakStatementSyntax node)
-        => node.Update(VisitList(node.AttributeLists), VisitToken(node.BreakKeyword), VisitToken(node.SemicolonToken));
+        => node.Update(VisitList(node.AttributeLists), VisitToken(node.BreakKeyword), (IdentifierNameSyntax?)Visit(node.Name), VisitToken(node.SemicolonToken));
 
     public override SyntaxNode? VisitContinueStatement(ContinueStatementSyntax node)
-        => node.Update(VisitList(node.AttributeLists), VisitToken(node.ContinueKeyword), VisitToken(node.SemicolonToken));
+        => node.Update(VisitList(node.AttributeLists), VisitToken(node.ContinueKeyword), (IdentifierNameSyntax?)Visit(node.Name), VisitToken(node.SemicolonToken));
 
     public override SyntaxNode? VisitReturnStatement(ReturnStatementSyntax node)
         => node.Update(VisitList(node.AttributeLists), VisitToken(node.ReturnKeyword), (ExpressionSyntax?)Visit(node.Expression), VisitToken(node.SemicolonToken));
@@ -4207,36 +4207,40 @@ public static partial class SyntaxFactory
 #pragma warning restore RS0027
 
     /// <summary>Creates a new BreakStatementSyntax instance.</summary>
-    public static BreakStatementSyntax BreakStatement(SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken breakKeyword, SyntaxToken semicolonToken)
+    public static BreakStatementSyntax BreakStatement(SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken breakKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken)
     {
         if (breakKeyword.Kind() != SyntaxKind.BreakKeyword) throw new ArgumentException(nameof(breakKeyword));
         if (semicolonToken.Kind() != SyntaxKind.SemicolonToken) throw new ArgumentException(nameof(semicolonToken));
-        return (BreakStatementSyntax)Syntax.InternalSyntax.SyntaxFactory.BreakStatement(attributeLists.Node.ToGreenList<Syntax.InternalSyntax.AttributeListSyntax>(), (Syntax.InternalSyntax.SyntaxToken)breakKeyword.Node!, (Syntax.InternalSyntax.SyntaxToken)semicolonToken.Node!).CreateRed();
+        return (BreakStatementSyntax)Syntax.InternalSyntax.SyntaxFactory.BreakStatement(attributeLists.Node.ToGreenList<Syntax.InternalSyntax.AttributeListSyntax>(), (Syntax.InternalSyntax.SyntaxToken)breakKeyword.Node!, name == null ? null : (Syntax.InternalSyntax.IdentifierNameSyntax)name.Green, (Syntax.InternalSyntax.SyntaxToken)semicolonToken.Node!).CreateRed();
     }
 
     /// <summary>Creates a new BreakStatementSyntax instance.</summary>
-    public static BreakStatementSyntax BreakStatement(SyntaxList<AttributeListSyntax> attributeLists)
-        => SyntaxFactory.BreakStatement(attributeLists, SyntaxFactory.Token(SyntaxKind.BreakKeyword), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+    public static BreakStatementSyntax BreakStatement(SyntaxList<AttributeListSyntax> attributeLists, IdentifierNameSyntax? name)
+        => SyntaxFactory.BreakStatement(attributeLists, SyntaxFactory.Token(SyntaxKind.BreakKeyword), name, SyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
+#pragma warning disable RS0027
     /// <summary>Creates a new BreakStatementSyntax instance.</summary>
-    public static BreakStatementSyntax BreakStatement()
-        => SyntaxFactory.BreakStatement(default, SyntaxFactory.Token(SyntaxKind.BreakKeyword), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+    public static BreakStatementSyntax BreakStatement(IdentifierNameSyntax? name = default)
+        => SyntaxFactory.BreakStatement(default, SyntaxFactory.Token(SyntaxKind.BreakKeyword), name, SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+#pragma warning restore RS0027
 
     /// <summary>Creates a new ContinueStatementSyntax instance.</summary>
-    public static ContinueStatementSyntax ContinueStatement(SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken continueKeyword, SyntaxToken semicolonToken)
+    public static ContinueStatementSyntax ContinueStatement(SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken continueKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken)
     {
         if (continueKeyword.Kind() != SyntaxKind.ContinueKeyword) throw new ArgumentException(nameof(continueKeyword));
         if (semicolonToken.Kind() != SyntaxKind.SemicolonToken) throw new ArgumentException(nameof(semicolonToken));
-        return (ContinueStatementSyntax)Syntax.InternalSyntax.SyntaxFactory.ContinueStatement(attributeLists.Node.ToGreenList<Syntax.InternalSyntax.AttributeListSyntax>(), (Syntax.InternalSyntax.SyntaxToken)continueKeyword.Node!, (Syntax.InternalSyntax.SyntaxToken)semicolonToken.Node!).CreateRed();
+        return (ContinueStatementSyntax)Syntax.InternalSyntax.SyntaxFactory.ContinueStatement(attributeLists.Node.ToGreenList<Syntax.InternalSyntax.AttributeListSyntax>(), (Syntax.InternalSyntax.SyntaxToken)continueKeyword.Node!, name == null ? null : (Syntax.InternalSyntax.IdentifierNameSyntax)name.Green, (Syntax.InternalSyntax.SyntaxToken)semicolonToken.Node!).CreateRed();
     }
 
     /// <summary>Creates a new ContinueStatementSyntax instance.</summary>
-    public static ContinueStatementSyntax ContinueStatement(SyntaxList<AttributeListSyntax> attributeLists)
-        => SyntaxFactory.ContinueStatement(attributeLists, SyntaxFactory.Token(SyntaxKind.ContinueKeyword), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+    public static ContinueStatementSyntax ContinueStatement(SyntaxList<AttributeListSyntax> attributeLists, IdentifierNameSyntax? name)
+        => SyntaxFactory.ContinueStatement(attributeLists, SyntaxFactory.Token(SyntaxKind.ContinueKeyword), name, SyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
+#pragma warning disable RS0027
     /// <summary>Creates a new ContinueStatementSyntax instance.</summary>
-    public static ContinueStatementSyntax ContinueStatement()
-        => SyntaxFactory.ContinueStatement(default, SyntaxFactory.Token(SyntaxKind.ContinueKeyword), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+    public static ContinueStatementSyntax ContinueStatement(IdentifierNameSyntax? name = default)
+        => SyntaxFactory.ContinueStatement(default, SyntaxFactory.Token(SyntaxKind.ContinueKeyword), name, SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+#pragma warning restore RS0027
 
     /// <summary>Creates a new ReturnStatementSyntax instance.</summary>
     public static ReturnStatementSyntax ReturnStatement(SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken returnKeyword, ExpressionSyntax? expression, SyntaxToken semicolonToken)

--- a/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Syntax.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/CSharpSyntaxGenerator/CSharpSyntaxGenerator.SourceGenerator/Syntax.xml.Syntax.Generated.cs
@@ -7163,6 +7163,7 @@ public sealed partial class GotoStatementSyntax : StatementSyntax
 public sealed partial class BreakStatementSyntax : StatementSyntax
 {
     private SyntaxNode? attributeLists;
+    private IdentifierNameSyntax? name;
 
     internal BreakStatementSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
       : base(green, parent, position)
@@ -7173,20 +7174,34 @@ public sealed partial class BreakStatementSyntax : StatementSyntax
 
     public SyntaxToken BreakKeyword => new SyntaxToken(this, ((InternalSyntax.BreakStatementSyntax)this.Green).breakKeyword, GetChildPosition(1), GetChildIndex(1));
 
-    public SyntaxToken SemicolonToken => new SyntaxToken(this, ((InternalSyntax.BreakStatementSyntax)this.Green).semicolonToken, GetChildPosition(2), GetChildIndex(2));
+    public IdentifierNameSyntax? Name => GetRed(ref this.name, 2);
 
-    internal override SyntaxNode? GetNodeSlot(int index) => index == 0 ? GetRedAtZero(ref this.attributeLists)! : null;
+    public SyntaxToken SemicolonToken => new SyntaxToken(this, ((InternalSyntax.BreakStatementSyntax)this.Green).semicolonToken, GetChildPosition(3), GetChildIndex(3));
 
-    internal override SyntaxNode? GetCachedSlot(int index) => index == 0 ? this.attributeLists : null;
+    internal override SyntaxNode? GetNodeSlot(int index)
+        => index switch
+        {
+            0 => GetRedAtZero(ref this.attributeLists)!,
+            2 => GetRed(ref this.name, 2),
+            _ => null,
+        };
+
+    internal override SyntaxNode? GetCachedSlot(int index)
+        => index switch
+        {
+            0 => this.attributeLists,
+            2 => this.name,
+            _ => null,
+        };
 
     public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitBreakStatement(this);
     public override TResult? Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) where TResult : default => visitor.VisitBreakStatement(this);
 
-    public BreakStatementSyntax Update(SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken breakKeyword, SyntaxToken semicolonToken)
+    public BreakStatementSyntax Update(SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken breakKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken)
     {
-        if (attributeLists != this.AttributeLists || breakKeyword != this.BreakKeyword || semicolonToken != this.SemicolonToken)
+        if (attributeLists != this.AttributeLists || breakKeyword != this.BreakKeyword || name != this.Name || semicolonToken != this.SemicolonToken)
         {
-            var newNode = SyntaxFactory.BreakStatement(attributeLists, breakKeyword, semicolonToken);
+            var newNode = SyntaxFactory.BreakStatement(attributeLists, breakKeyword, name, semicolonToken);
             var annotations = GetAnnotations();
             return annotations?.Length > 0 ? newNode.WithAnnotations(annotations) : newNode;
         }
@@ -7195,9 +7210,10 @@ public sealed partial class BreakStatementSyntax : StatementSyntax
     }
 
     internal override StatementSyntax WithAttributeListsCore(SyntaxList<AttributeListSyntax> attributeLists) => WithAttributeLists(attributeLists);
-    public new BreakStatementSyntax WithAttributeLists(SyntaxList<AttributeListSyntax> attributeLists) => Update(attributeLists, this.BreakKeyword, this.SemicolonToken);
-    public BreakStatementSyntax WithBreakKeyword(SyntaxToken breakKeyword) => Update(this.AttributeLists, breakKeyword, this.SemicolonToken);
-    public BreakStatementSyntax WithSemicolonToken(SyntaxToken semicolonToken) => Update(this.AttributeLists, this.BreakKeyword, semicolonToken);
+    public new BreakStatementSyntax WithAttributeLists(SyntaxList<AttributeListSyntax> attributeLists) => Update(attributeLists, this.BreakKeyword, this.Name, this.SemicolonToken);
+    public BreakStatementSyntax WithBreakKeyword(SyntaxToken breakKeyword) => Update(this.AttributeLists, breakKeyword, this.Name, this.SemicolonToken);
+    public BreakStatementSyntax WithName(IdentifierNameSyntax? name) => Update(this.AttributeLists, this.BreakKeyword, name, this.SemicolonToken);
+    public BreakStatementSyntax WithSemicolonToken(SyntaxToken semicolonToken) => Update(this.AttributeLists, this.BreakKeyword, this.Name, semicolonToken);
 
     internal override StatementSyntax AddAttributeListsCore(params AttributeListSyntax[] items) => AddAttributeLists(items);
     public new BreakStatementSyntax AddAttributeLists(params AttributeListSyntax[] items) => WithAttributeLists(this.AttributeLists.AddRange(items));
@@ -7212,6 +7228,7 @@ public sealed partial class BreakStatementSyntax : StatementSyntax
 public sealed partial class ContinueStatementSyntax : StatementSyntax
 {
     private SyntaxNode? attributeLists;
+    private IdentifierNameSyntax? name;
 
     internal ContinueStatementSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
       : base(green, parent, position)
@@ -7222,20 +7239,34 @@ public sealed partial class ContinueStatementSyntax : StatementSyntax
 
     public SyntaxToken ContinueKeyword => new SyntaxToken(this, ((InternalSyntax.ContinueStatementSyntax)this.Green).continueKeyword, GetChildPosition(1), GetChildIndex(1));
 
-    public SyntaxToken SemicolonToken => new SyntaxToken(this, ((InternalSyntax.ContinueStatementSyntax)this.Green).semicolonToken, GetChildPosition(2), GetChildIndex(2));
+    public IdentifierNameSyntax? Name => GetRed(ref this.name, 2);
 
-    internal override SyntaxNode? GetNodeSlot(int index) => index == 0 ? GetRedAtZero(ref this.attributeLists)! : null;
+    public SyntaxToken SemicolonToken => new SyntaxToken(this, ((InternalSyntax.ContinueStatementSyntax)this.Green).semicolonToken, GetChildPosition(3), GetChildIndex(3));
 
-    internal override SyntaxNode? GetCachedSlot(int index) => index == 0 ? this.attributeLists : null;
+    internal override SyntaxNode? GetNodeSlot(int index)
+        => index switch
+        {
+            0 => GetRedAtZero(ref this.attributeLists)!,
+            2 => GetRed(ref this.name, 2),
+            _ => null,
+        };
+
+    internal override SyntaxNode? GetCachedSlot(int index)
+        => index switch
+        {
+            0 => this.attributeLists,
+            2 => this.name,
+            _ => null,
+        };
 
     public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitContinueStatement(this);
     public override TResult? Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) where TResult : default => visitor.VisitContinueStatement(this);
 
-    public ContinueStatementSyntax Update(SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken continueKeyword, SyntaxToken semicolonToken)
+    public ContinueStatementSyntax Update(SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken continueKeyword, IdentifierNameSyntax? name, SyntaxToken semicolonToken)
     {
-        if (attributeLists != this.AttributeLists || continueKeyword != this.ContinueKeyword || semicolonToken != this.SemicolonToken)
+        if (attributeLists != this.AttributeLists || continueKeyword != this.ContinueKeyword || name != this.Name || semicolonToken != this.SemicolonToken)
         {
-            var newNode = SyntaxFactory.ContinueStatement(attributeLists, continueKeyword, semicolonToken);
+            var newNode = SyntaxFactory.ContinueStatement(attributeLists, continueKeyword, name, semicolonToken);
             var annotations = GetAnnotations();
             return annotations?.Length > 0 ? newNode.WithAnnotations(annotations) : newNode;
         }
@@ -7244,9 +7275,10 @@ public sealed partial class ContinueStatementSyntax : StatementSyntax
     }
 
     internal override StatementSyntax WithAttributeListsCore(SyntaxList<AttributeListSyntax> attributeLists) => WithAttributeLists(attributeLists);
-    public new ContinueStatementSyntax WithAttributeLists(SyntaxList<AttributeListSyntax> attributeLists) => Update(attributeLists, this.ContinueKeyword, this.SemicolonToken);
-    public ContinueStatementSyntax WithContinueKeyword(SyntaxToken continueKeyword) => Update(this.AttributeLists, continueKeyword, this.SemicolonToken);
-    public ContinueStatementSyntax WithSemicolonToken(SyntaxToken semicolonToken) => Update(this.AttributeLists, this.ContinueKeyword, semicolonToken);
+    public new ContinueStatementSyntax WithAttributeLists(SyntaxList<AttributeListSyntax> attributeLists) => Update(attributeLists, this.ContinueKeyword, this.Name, this.SemicolonToken);
+    public ContinueStatementSyntax WithContinueKeyword(SyntaxToken continueKeyword) => Update(this.AttributeLists, continueKeyword, this.Name, this.SemicolonToken);
+    public ContinueStatementSyntax WithName(IdentifierNameSyntax? name) => Update(this.AttributeLists, this.ContinueKeyword, name, this.SemicolonToken);
+    public ContinueStatementSyntax WithSemicolonToken(SyntaxToken semicolonToken) => Update(this.AttributeLists, this.ContinueKeyword, this.Name, semicolonToken);
 
     internal override StatementSyntax AddAttributeListsCore(params AttributeListSyntax[] items) => AddAttributeLists(items);
     public new ContinueStatementSyntax AddAttributeLists(params AttributeListSyntax[] items) => WithAttributeLists(this.AttributeLists.AddRange(items));

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -9329,6 +9329,7 @@ done:
             return _syntaxFactory.BreakStatement(
                 attributes,
                 this.EatToken(SyntaxKind.BreakKeyword),
+                this.IsTrueIdentifier() ? this.ParseIdentifierName() : null,
                 this.EatToken(SyntaxKind.SemicolonToken));
         }
 
@@ -9337,6 +9338,7 @@ done:
             return _syntaxFactory.ContinueStatement(
                 attributes,
                 this.EatToken(SyntaxKind.ContinueKeyword),
+                this.IsTrueIdentifier() ? this.ParseIdentifierName() : null,
                 this.EatToken(SyntaxKind.SemicolonToken));
         }
 

--- a/src/Compilers/CSharp/Portable/Syntax/BreakStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/BreakStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class BreakStatementSyntax
     {
         public BreakStatementSyntax Update(SyntaxToken breakKeyword, SyntaxToken semicolonToken)
-            => Update(AttributeLists, breakKeyword, semicolonToken);
+            => Update(AttributeLists, breakKeyword, Name, semicolonToken);
     }
 }
 
@@ -18,6 +18,6 @@ namespace Microsoft.CodeAnalysis.CSharp
     public partial class SyntaxFactory
     {
         public static BreakStatementSyntax BreakStatement(SyntaxToken breakKeyword, SyntaxToken semicolonToken)
-            => BreakStatement(attributeLists: default, breakKeyword, semicolonToken);
+            => BreakStatement(attributeLists: default, breakKeyword, name: null, semicolonToken);
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/ContinueStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/ContinueStatementSyntax.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     public partial class ContinueStatementSyntax
     {
         public ContinueStatementSyntax Update(SyntaxToken continueKeyword, SyntaxToken semicolonToken)
-            => Update(AttributeLists, continueKeyword, semicolonToken);
+            => Update(AttributeLists, continueKeyword, Name, semicolonToken);
     }
 }
 
@@ -18,6 +18,6 @@ namespace Microsoft.CodeAnalysis.CSharp
     public partial class SyntaxFactory
     {
         public static ContinueStatementSyntax ContinueStatement(SyntaxToken continueKeyword, SyntaxToken semicolonToken)
-            => ContinueStatement(attributeLists: default, continueKeyword, semicolonToken);
+            => ContinueStatement(attributeLists: default, continueKeyword, name: null, semicolonToken);
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -2468,6 +2468,7 @@
     <Field Name="BreakKeyword" Type="SyntaxToken">
       <Kind Name="BreakKeyword"/>
     </Field>
+    <Field Name="Name" Type="IdentifierNameSyntax" Optional="true"/>
     <Field Name="SemicolonToken" Type="SyntaxToken">
       <Kind Name="SemicolonToken"/>
     </Field>
@@ -2478,6 +2479,7 @@
     <Field Name="ContinueKeyword" Type="SyntaxToken">
       <Kind Name="ContinueKeyword"/>
     </Field>
+    <Field Name="Name" Type="IdentifierNameSyntax" Optional="true"/>
     <Field Name="SemicolonToken" Type="SyntaxToken">
       <Kind Name="SemicolonToken"/>
     </Field>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">Argument diagnosticId atributu Experimental musí být platný identifikátor</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">{0} neobsahuje definici pro {1} a nebyla nalezena žádná přístupná metoda rozšíření {1}, která by přijímala první argument typu {0}. (Nechtěli jste místo toho iterovat asynchronní kolekci pomocí await foreach?)</target>
@@ -2995,6 +3010,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">člen instance v nameof</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">Argument diagnosticId atributu Experimental musí být platný identifikátor</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">{0} neobsahuje definici pro {1} a nebyla nalezena žádná přístupná metoda rozšíření {1}, která by přijímala první argument typu {0}. (Nechtěli jste místo toho iterovat asynchronní kolekci pomocí await foreach?)</target>
@@ -6678,6 +6663,11 @@
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">Příkazy break a continue nejsou uvedené ve smyčce.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">Das diagnosticId-Argument für das Experimental-Attribut muss ein gültiger Bezeichner sein.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">„{0}“ enthält keine Definition für „{1}“, und es konnte keine zugängliche Erweiterungsmethode „{1}“ gefunden werden, die ein erstes Argument vom Typ „{0}“ akzeptiert (wollten Sie die asynchrone Sammlung mit „await foreach“ durchlaufen?)</target>
@@ -6678,6 +6663,11 @@
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">Keine einschließende Schleife, aus der angehalten und fortgefahren werden kann.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">Das diagnosticId-Argument für das Experimental-Attribut muss ein gültiger Bezeichner sein.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">„{0}“ enthält keine Definition für „{1}“, und es konnte keine zugängliche Erweiterungsmethode „{1}“ gefunden werden, die ein erstes Argument vom Typ „{0}“ akzeptiert (wollten Sie die asynchrone Sammlung mit „await foreach“ durchlaufen?)</target>
@@ -2995,6 +3010,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">Instanzmember in "nameof"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">El argumento diagnosticId del atributo "Experimental" debe ser un identificador válido.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">'{0}' no contiene una definición para '{1}' y no se encontró ningún método de extensión accesible '{1}' aceptando un primer argumento de tipo '{0}' (¿pretendía iterar por la colección asincrónica con 'await foreach' en su lugar?)</target>
@@ -2995,6 +3010,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">miembro de instancia en 'nameof'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">El argumento diagnosticId del atributo "Experimental" debe ser un identificador válido.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">'{0}' no contiene una definición para '{1}' y no se encontró ningún método de extensión accesible '{1}' aceptando un primer argumento de tipo '{0}' (¿pretendía iterar por la colección asincrónica con 'await foreach' en su lugar?)</target>
@@ -6678,6 +6663,11 @@
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">No hay ningún bucle envolvente desde el que interrumpir o continuar</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">L’argument diagnosticId de l’attribut « Experimental » doit être un identificateur valide</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">« {0} » ne contient pas de définition pour « {1} » et aucune méthode d’extension accessible « {1} » acceptant un premier argument de type « {0} » n’a pu être trouvée (vouliez-vous plutôt itérer la collection asynchrone avec « await foreach » ?)</target>
@@ -6678,6 +6663,11 @@
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">Absence de boucle englobant 'break' ou 'continue'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">L’argument diagnosticId de l’attribut « Experimental » doit être un identificateur valide</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">« {0} » ne contient pas de définition pour « {1} » et aucune méthode d’extension accessible « {1} » acceptant un premier argument de type « {0} » n’a pu être trouvée (vouliez-vous plutôt itérer la collection asynchrone avec « await foreach » ?)</target>
@@ -2995,6 +3010,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">membre d'instance dans 'nameof'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">L'argomento diagnosticId dell'attributo 'Experimental' deve essere un identificatore valido</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">'{0}' non contiene una definizione per '{1}' e non è possibile trovare alcun metodo di estensione accessibile '{1}' che accetta un primo argomento di tipo '{0}' (si intendeva forse eseguire l'iterazione sulla raccolta asincrona con 'await foreach'?)</target>
@@ -2995,6 +3010,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">membro di istanza in 'nameof'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">L'argomento diagnosticId dell'attributo 'Experimental' deve essere un identificatore valido</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">'{0}' non contiene una definizione per '{1}' e non è possibile trovare alcun metodo di estensione accessibile '{1}' che accetta un primo argomento di tipo '{0}' (si intendeva forse eseguire l'iterazione sulla raccolta asincrona con 'await foreach'?)</target>
@@ -6678,6 +6663,11 @@ target:module               Compila un modulo che può essere aggiunto ad altro
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">Non esiste alcun ciclo di inclusione all'esterno del quale interrompere o continuare</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">'Experimental' 属性への diagnosticId 引数は有効な識別子である必要があります</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">'{0}' に '{1}' の定義が含まれていません。また、型 '{0}' の最初の引数を受け入れるアクセス可能な拡張メソッド '{1}' が見つかりませんでした (代わりに 'await foreach' を使用して非同期コレクションを反復処理するつもりでしたか?)</target>
@@ -2995,6 +3010,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">'nameof' のインスタンス メンバー</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">'Experimental' 属性への diagnosticId 引数は有効な識別子である必要があります</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">'{0}' に '{1}' の定義が含まれていません。また、型 '{0}' の最初の引数を受け入れるアクセス可能な拡張メソッド '{1}' が見つかりませんでした (代わりに 'await foreach' を使用して非同期コレクションを反復処理するつもりでしたか?)</target>
@@ -6678,6 +6663,11 @@
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">break または continue に対応するループがありません</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">'Experimental' 특성에 대한 diagnosticId 인수는 유효한 식별자여야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">'{0}'에 '{1}'에 대한 정의가 없고, '{1}' 형식의 첫 번째 인수를 받는 액세스 가능한 확장 메서드 '{0}'을(를) 찾을 수 없습니다(대신 'await foreach'를 사용하여 비동기 컬렉션을 반복하려고 한 건가요?).</target>
@@ -2995,6 +3010,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">'nameof'의 인스턴스 멤버</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">'Experimental' 특성에 대한 diagnosticId 인수는 유효한 식별자여야 합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">'{0}'에 '{1}'에 대한 정의가 없고, '{1}' 형식의 첫 번째 인수를 받는 액세스 가능한 확장 메서드 '{0}'을(를) 찾을 수 없습니다(대신 'await foreach'를 사용하여 비동기 컬렉션을 반복하려고 한 건가요?).</target>
@@ -6678,6 +6663,11 @@
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">break 또는 continue되어 빠져 나갈 루프가 없습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">Argument diagnosticId atrybutu „Experimental” musi być prawidłowym identyfikatorem</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">„{0}” nie zawiera definicji dla „{1}” i nie znaleziono dostępnej metody rozszerzenia „{1}”, która przyjmowałaby pierwszy argument typu „{0}” (czy chodziło Ci o iterację kolekcji asynchronicznej za pomocą polecenia „await foreach”?)</target>
@@ -6678,6 +6663,11 @@
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">Brak pętli otaczającej, w której ma nastąpić przerwanie lub kontynuowanie</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">Argument diagnosticId atrybutu „Experimental” musi być prawidłowym identyfikatorem</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">„{0}” nie zawiera definicji dla „{1}” i nie znaleziono dostępnej metody rozszerzenia „{1}”, która przyjmowałaby pierwszy argument typu „{0}” (czy chodziło Ci o iterację kolekcji asynchronicznej za pomocą polecenia „await foreach”?)</target>
@@ -2995,6 +3010,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">składowa wystąpienia w elemencie „nameof”</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">O argumento diagnosticId para o atributo 'Experimental' deve ser um identificador válido</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">'{0}' não contém uma definição para '{1}' e nenhum método de extensão acessível '{1}' que aceite um primeiro argumento do tipo '{0}' pôde ser encontrado (você quis iterar sobre a coleção assíncrona usando 'await foreach'?)</target>
@@ -2995,6 +3010,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">membro da instância em 'nameof'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">O argumento diagnosticId para o atributo 'Experimental' deve ser um identificador válido</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">'{0}' não contém uma definição para '{1}' e nenhum método de extensão acessível '{1}' que aceite um primeiro argumento do tipo '{0}' pôde ser encontrado (você quis iterar sobre a coleção assíncrona usando 'await foreach'?)</target>
@@ -6678,6 +6663,11 @@
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">Nenhum loop delimitador a partir do qual quebrar ou continuar</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">Аргумент diagnosticId атрибута "Experimental" должен быть допустимым идентификатором</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">"{0}" не содержит определение для "{1}", не найден доступный метод расширения "{1}", принимающий первый аргумент типа "{0}" (возможно, нужно было выполнить итерацию для синхронной коллекции с помощью "await foreach"?)</target>
@@ -6678,6 +6663,11 @@
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">Отсутствует внешний цикл для прерывания или продолжения.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">Аргумент diagnosticId атрибута "Experimental" должен быть допустимым идентификатором</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">"{0}" не содержит определение для "{1}", не найден доступный метод расширения "{1}", принимающий первый аргумент типа "{0}" (возможно, нужно было выполнить итерацию для синхронной коллекции с помощью "await foreach"?)</target>
@@ -2995,6 +3010,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">элемент экземпляра в "nameof"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">'Experimental' özniteliğinin diagnosticId bağımsız değişkeni geçerli bir tanımlayıcı olmalıdır</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">' {0}' '{1}' için bir tanım içermiyor ve '{0}' türünden ilk bağımsız değişkeni kabul eden erişilebilir '{1}' uzantı yöntemi bulunamadı (zaman uyumsuz koleksiyon üzerinde 'await foreach' ile yineleme yapmak mı istediniz?)</target>
@@ -6678,6 +6663,11 @@
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">Durdurulacak veya devam ettirilecek kapsayan bir döngü yok</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">'Experimental' özniteliğinin diagnosticId bağımsız değişkeni geçerli bir tanımlayıcı olmalıdır</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">' {0}' '{1}' için bir tanım içermiyor ve '{0}' türünden ilk bağımsız değişkeni kabul eden erişilebilir '{1}' uzantı yöntemi bulunamadı (zaman uyumsuz koleksiyon üzerinde 'await foreach' ile yineleme yapmak mı istediniz?)</target>
@@ -2995,6 +3010,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">'nameof' içinde örnek üyesi</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">“Experimental” 属性的 diagnosticId 参数必须是有效的标识符</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">“{0}”不包含“{1}”的定义，且找不到任何可访问的扩展方法“{1}”，其中该方法接受类型为“{0}”的第一个参数(是否想用 "await foreach" 来循环访问异步集合?)</target>
@@ -6678,6 +6663,11 @@
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">没有要中断或继续的封闭循环</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">“Experimental” 属性的 diagnosticId 参数必须是有效的标识符</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">“{0}”不包含“{1}”的定义，且找不到任何可访问的扩展方法“{1}”，其中该方法接受类型为“{0}”的第一个参数(是否想用 "await foreach" 来循环访问异步集合?)</target>
@@ -2995,6 +3010,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">"nameof" 中的实例成员</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">'Experimental' 屬性的 diagnosticId 引數必須是有效的識別碼</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">'{0}' 不包含 '{1}' 的定義，而且找不到接受類型 '{0}' 的第一個引數的可存取方法 '{1}' (您是否要改為使用 'await foreach' 來逐一查看非同步集合?)</target>
@@ -2995,6 +3010,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">'nameof' 中的執行個體成員</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">'Experimental' 屬性的 diagnosticId 引數必須是有效的識別碼</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">'{0}' 不包含 '{1}' 的定義，而且找不到接受類型 '{0}' 的第一個引數的可存取方法 '{1}' (您是否要改為使用 'await foreach' 來逐一查看非同步集合?)</target>
@@ -6678,6 +6663,11 @@ strument:TestCoverage      產生檢測要收集
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">沒有可中斷或繼續的封閉式迴圈</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Test/CSharp15/LabeledBreakContinueBindingTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/LabeledBreakContinueBindingTests.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests;
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
 
 public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
 {
@@ -32,10 +32,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -54,10 +51,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -75,10 +69,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: do
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -97,10 +88,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: do
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -120,9 +108,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: for (int i = 0; i < 10; i++)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
             // (7,37): warning CS0162: Unreachable code detected
             //             for (int j = 0; j < 10; j++)
             Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(7, 37));
@@ -145,9 +130,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: for (int i = 0; i < 10; i++)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
             // (7,37): warning CS0162: Unreachable code detected
             //             for (int j = 0; j < 10; j++)
             Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(7, 37));
@@ -169,10 +151,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: foreach (var a in args)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -191,10 +170,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: foreach (var a in args)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -213,10 +189,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: foreach (var (x, y) in items)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     #endregion
@@ -240,10 +213,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: switch (x)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -265,10 +235,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -291,10 +258,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: switch (x)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     #endregion
@@ -357,15 +321,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         L0: while (a-- > 0)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L0").WithLocation(5, 9),
-            // (7,13): warning CS0164: This label has not been referenced
-            //             L1: switch (b)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L1").WithLocation(7, 13),
-            // (10,21): warning CS0164: This label has not been referenced
-            //                     L2: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L2").WithLocation(10, 21),
             // (16,21): warning CS0162: Unreachable code detected
             //                     break;
             Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(16, 21));
@@ -394,10 +349,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -419,9 +371,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: for (int i = 0; i < 10; i++)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
             // (5,40): warning CS0162: Unreachable code detected
             //         outer: for (int i = 0; i < 10; i++)
             Diagnostic(ErrorCode.WRN_UnreachableCode, "i").WithLocation(5, 40));
@@ -446,10 +395,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -473,10 +419,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -500,9 +443,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (6,9): warning CS0164: This label has not been referenced
-            //         outer: for (int i = 0; i < 1; i++)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(6, 9),
             // (8,36): warning CS0162: Unreachable code detected
             //             for (int j = 0; j < 1; j++)
             Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(8, 36));
@@ -525,10 +465,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (6,9): warning CS0164: This label has not been referenced
-            //         outer: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(6, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -569,10 +506,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         L: for (;;)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -590,10 +524,185 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
+        CreateCompilation(source).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Break_UnreachableLabeledBreak_StillSuppressesWarning()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        break;
+                        break outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (8,13): warning CS0162: Unreachable code detected
+            //             break outer;
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(8, 13));
+    }
+
+    [Fact]
+    public void Continue_UnreachableLabeledContinue_StillSuppressesWarning()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        break;
+                        continue outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (8,13): warning CS0162: Unreachable code detected
+            //             continue outer;
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "continue").WithLocation(8, 13));
+    }
+
+    [Fact]
+    public void Break_StackedLabels_OnlyValidLabelReferenced()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    a: b: c: while (true)
+                    {
+                        break c;
+                    }
+                }
+            }
+            """;
         CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
-            //         \u006Futer: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, @"\u006Futer").WithLocation(5, 9));
+            //         a: b: c: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "a").WithLocation(5, 9),
+            // (5,12): warning CS0164: This label has not been referenced
+            //         a: b: c: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "b").WithLocation(5, 12));
+    }
+
+    [Fact]
+    public void Break_MultipleLabeledBreaksToSameLabel()
+    {
+        var source = """
+            class C
+            {
+                void M(bool x)
+                {
+                    outer: while (true)
+                    {
+                        if (x)
+                            break outer;
+                        else
+                            break outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Continue_MultipleLabeledContinuesToSameLabel()
+    {
+        var source = """
+            class C
+            {
+                void M(bool x)
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        if (x)
+                            continue outer;
+                        else
+                            continue outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Break_MixedUnlabeledAndLabeledExits()
+    {
+        var source = """
+            class C
+            {
+                void M(bool cond)
+                {
+                    outer: while (true)
+                    {
+                        while (cond)
+                            break;
+                        break outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Break_LabeledBreakFirst_GotoUnreachable()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    L: while (true)
+                    {
+                        break L;
+                        goto L;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (8,13): warning CS0162: Unreachable code detected
+            //             goto L;
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "goto").WithLocation(8, 13));
+    }
+
+    [Fact]
+    public void Break_InCatch_WithFinally_TargetsOuterLoop()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        try
+                        {
+                            throw new System.Exception();
+                        }
+                        catch
+                        {
+                            break outer;
+                        }
+                        finally { }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     #endregion
@@ -1091,6 +1200,104 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             Diagnostic(ErrorCode.ERR_NoBreakOrContId, "outer").WithArguments("outer").WithLocation(7, 15));
     }
 
+    [Fact]
+    public void Break_InsideLambda_TargetsLoopInsideLambda()
+    {
+        var source = """
+            using System;
+            class C
+            {
+                void M()
+                {
+                    Action a = () =>
+                    {
+                        outer: while (true)
+                        {
+                            while (true)
+                                break outer;
+                        }
+                    };
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Continue_InsideLambda_TargetsLoopInsideLambda()
+    {
+        var source = """
+            using System;
+            class C
+            {
+                void M()
+                {
+                    Action a = () =>
+                    {
+                        outer: for (int i = 0; i < 10; i++)
+                        {
+                            for (int j = 0; j < 10; j++)
+                                continue outer;
+                        }
+                    };
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (10,41): warning CS0162: Unreachable code detected
+            //                     for (int j = 0; j < 10; j++)
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(10, 41));
+    }
+
+    [Fact]
+    public void Break_InsideLocalFunction_TargetsLoopInsideLocalFunction()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    void F()
+                    {
+                        outer: while (true)
+                        {
+                            while (true)
+                                break outer;
+                        }
+                    }
+                    F();
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Continue_InsideLocalFunction_TargetsLoopInsideLocalFunction()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    void F()
+                    {
+                        outer: for (int i = 0; i < 10; i++)
+                        {
+                            for (int j = 0; j < 10; j++)
+                                continue outer;
+                        }
+                    }
+                    F();
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (9,41): warning CS0162: Unreachable code detected
+            //                     for (int j = 0; j < 10; j++)
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(9, 41));
+    }
+
     #endregion
 
     #region Finally blocks
@@ -1112,9 +1319,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: for (int i = 0; i < 10; i++)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
             // (5,40): warning CS0162: Unreachable code detected
             //         outer: for (int i = 0; i < 10; i++)
             Diagnostic(ErrorCode.WRN_UnreachableCode, "i").WithLocation(5, 40),
@@ -1140,12 +1344,58 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: for (int i = 0; i < 10; i++)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
             // (8,23): error CS0157: Control cannot leave the body of a finally clause
             //             finally { continue outer; }
             Diagnostic(ErrorCode.ERR_BadFinallyLeave, "continue").WithLocation(8, 23));
+    }
+
+    [Fact]
+    public void Break_InFinally_TargetsLoopInsideFinally()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    try { }
+                    finally
+                    {
+                        outer: while (true)
+                        {
+                            while (true)
+                                break outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Continue_InFinally_TargetsLoopInsideFinally()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    try { }
+                    finally
+                    {
+                        outer: for (int i = 0; i < 10; i++)
+                        {
+                            for (int j = 0; j < 10; j++)
+                                continue outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (10,41): warning CS0162: Unreachable code detected
+            //                     for (int j = 0; j < 10; j++)
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(10, 41));
     }
 
     [Fact]
@@ -1164,10 +1414,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     #endregion
@@ -1188,9 +1435,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
             // (6,19): error CS8652: The feature 'labeled break and continue' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //             break outer;
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "outer").WithArguments("labeled break and continue").WithLocation(6, 19));
@@ -1213,9 +1457,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: for (int i = 0; i < 10; i++)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
             // (7,37): warning CS0162: Unreachable code detected
             //             for (int j = 0; j < 10; j++)
             Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(7, 37),
@@ -1236,12 +1477,43 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 break outer;
             """;
         CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
-            // (1,1): warning CS0164: This label has not been referenced
-            // outer: for (int i = 0; i < 1; i++)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(1, 1),
             // (1,31): warning CS0162: Unreachable code detected
             // outer: for (int i = 0; i < 1; i++)
             Diagnostic(ErrorCode.WRN_UnreachableCode, "i").WithLocation(1, 31));
+    }
+
+    [Fact]
+    public void Continue_TopLevelStatements()
+    {
+        var source = """
+            outer: for (int i = 0; i < 10; i++)
+            {
+                for (int j = 0; j < 10; j++)
+                    continue outer;
+            }
+            """;
+        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+            // (3,29): warning CS0162: Unreachable code detected
+            //     for (int j = 0; j < 10; j++)
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(3, 29));
+    }
+
+    [Fact]
+    public void Break_TopLevelStatements_Switch()
+    {
+        var source = """
+            int x = 0;
+            outer: switch (x)
+            {
+                case 0:
+                    switch (x)
+                    {
+                        case 0: break outer;
+                    }
+                    break;
+            }
+            """;
+        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics();
     }
 
     #endregion

--- a/src/Compilers/CSharp/Test/CSharp15/LabeledBreakContinueEmitTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/LabeledBreakContinueEmitTests.cs
@@ -1,0 +1,1095 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+public sealed class LabeledBreakContinueEmitTests : CSharpTestBase
+{
+    #region while
+
+    [Fact]
+    public void Break_While_Immediate()
+    {
+        var source = """
+            outer: while (true)
+            {
+                System.Console.Write("A ");
+                break outer;
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "A done");
+    }
+
+    [Fact]
+    public void Break_While_Nested()
+    {
+        var source = """
+            outer: while (true)
+            {
+                while (true)
+                {
+                    System.Console.Write("A ");
+                    break outer;
+                }
+                System.Console.Write("SKIPPED ");
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "A done");
+    }
+
+    [Fact]
+    public void Continue_While_Immediate()
+    {
+        var source = """
+            int i = 0;
+            outer: while (i < 3)
+            {
+                i++;
+                System.Console.Write(i + " ");
+                continue outer;
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "1 2 3 done");
+    }
+
+    [Fact]
+    public void Continue_While_Nested()
+    {
+        var source = """
+            int i = 0;
+            outer: while (i < 3)
+            {
+                i++;
+                while (true)
+                {
+                    System.Console.Write(i + " ");
+                    continue outer;
+                }
+                System.Console.Write("SKIPPED ");
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "1 2 3 done");
+    }
+
+    #endregion
+
+    #region do/while
+
+    [Fact]
+    public void Break_DoWhile_Immediate()
+    {
+        var source = """
+            outer: do
+            {
+                System.Console.Write("A ");
+                break outer;
+            } while (true);
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "A done");
+    }
+
+    [Fact]
+    public void Break_DoWhile_Nested()
+    {
+        var source = """
+            outer: do
+            {
+                do
+                {
+                    System.Console.Write("A ");
+                    break outer;
+                } while (true);
+                System.Console.Write("SKIPPED ");
+            } while (true);
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "A done");
+    }
+
+    [Fact]
+    public void Continue_DoWhile_Immediate()
+    {
+        var source = """
+            int i = 0;
+            outer: do
+            {
+                i++;
+                System.Console.Write(i + " ");
+                continue outer;
+            } while (i < 3);
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "1 2 3 done");
+    }
+
+    [Fact]
+    public void Continue_DoWhile_Nested()
+    {
+        var source = """
+            int i = 0;
+            outer: do
+            {
+                i++;
+                while (true)
+                {
+                    System.Console.Write(i + " ");
+                    continue outer;
+                }
+                System.Console.Write("SKIPPED ");
+            } while (i < 3);
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "1 2 3 done");
+    }
+
+    #endregion
+
+    #region for
+
+    [Fact]
+    public void Break_For_Immediate()
+    {
+        var source = """
+            outer: for (int i = 0; ; i++)
+            {
+                System.Console.Write(i + " ");
+                break outer;
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "0 done");
+    }
+
+    [Fact]
+    public void Break_For_Nested()
+    {
+        var source = """
+            outer: for (int i = 0; i < 3; i++)
+            {
+                for (int j = 0; ; j++)
+                {
+                    System.Console.Write($"({i},{j}) ");
+                    break outer;
+                }
+                System.Console.Write("SKIPPED ");
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "(0,0) done");
+    }
+
+    [Fact]
+    public void Continue_For_Immediate()
+    {
+        var source = """
+            outer: for (int i = 0; i < 3; i++)
+            {
+                System.Console.Write(i + " ");
+                continue outer;
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "0 1 2 done");
+    }
+
+    [Fact]
+    public void Continue_For_Nested()
+    {
+        var source = """
+            outer: for (int i = 0; i < 3; i++)
+            {
+                for (int j = 0; ; j++)
+                {
+                    System.Console.Write($"({i},{j}) ");
+                    continue outer;
+                }
+                System.Console.Write("SKIPPED ");
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "(0,0) (1,0) (2,0) done");
+    }
+
+    #endregion
+
+    #region foreach
+
+    [Fact]
+    public void Break_ForEach_Immediate()
+    {
+        var source = """
+            outer: foreach (var x in new[] { 1, 2, 3 })
+            {
+                System.Console.Write(x + " ");
+                break outer;
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "1 done");
+    }
+
+    [Fact]
+    public void Break_ForEach_Nested()
+    {
+        var source = """
+            outer: foreach (var x in new[] { 1, 2, 3 })
+            {
+                foreach (var y in new[] { 10, 20 })
+                {
+                    System.Console.Write($"{x}+{y} ");
+                    break outer;
+                }
+                System.Console.Write("SKIPPED ");
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "1+10 done");
+    }
+
+    [Fact]
+    public void Continue_ForEach_Immediate()
+    {
+        var source = """
+            outer: foreach (var x in new[] { 1, 2, 3 })
+            {
+                System.Console.Write(x + " ");
+                continue outer;
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "1 2 3 done");
+    }
+
+    [Fact]
+    public void Continue_ForEach_Nested()
+    {
+        var source = """
+            outer: foreach (var x in new[] { 1, 2, 3 })
+            {
+                foreach (var y in new[] { 10, 20 })
+                {
+                    System.Console.Write($"{x}+{y} ");
+                    continue outer;
+                }
+                System.Console.Write("SKIPPED ");
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "1+10 2+10 3+10 done");
+    }
+
+    #endregion
+
+    #region switch
+
+    [Fact]
+    public void Break_Switch_Immediate()
+    {
+        var source = """
+            int x = 1;
+            outer: switch (x)
+            {
+                case 1:
+                    System.Console.Write("case1 ");
+                    break outer;
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "case1 done");
+    }
+
+    [Fact]
+    public void Break_Switch_Nested()
+    {
+        var source = """
+            outer: while (true)
+            {
+                switch (1)
+                {
+                    case 1:
+                        System.Console.Write("inner ");
+                        break outer;
+                }
+                System.Console.Write("SKIPPED ");
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "inner done");
+    }
+
+    [Fact]
+    public void Break_Switch_FromNestedSwitch()
+    {
+        var source = """
+            outer: switch (1)
+            {
+                case 1:
+                    switch (2)
+                    {
+                        case 2:
+                            System.Console.Write("nested ");
+                            break outer;
+                    }
+                    System.Console.Write("SKIPPED ");
+                    break;
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "nested done");
+    }
+
+    [Fact]
+    public void Continue_For_FromSwitch()
+    {
+        var source = """
+            outer: for (int i = 0; i < 3; i++)
+            {
+                switch (i)
+                {
+                    case 0:
+                        System.Console.Write("zero ");
+                        continue outer;
+                    case 1:
+                        System.Console.Write("one ");
+                        continue outer;
+                    default:
+                        System.Console.Write("other ");
+                        continue outer;
+                }
+                System.Console.Write("SKIPPED ");
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "zero one other done");
+    }
+
+    #endregion
+
+    #region IL verification
+
+    [Fact]
+    public void IL_Break_While_Nested()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b1, bool b2)
+                {
+                    outer: while (b1)
+                    {
+                        while (b2)
+                        {
+                            break outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size        9 (0x9)
+              .maxstack  1
+              IL_0000:  br.s       IL_0005
+              IL_0002:  ldarg.1
+              IL_0003:  brtrue.s   IL_0008
+              IL_0005:  ldarg.0
+              IL_0006:  brtrue.s   IL_0002
+              IL_0008:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Break_While_Nested_Conditional()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b1, bool b2, bool b3)
+                {
+                    outer: while (b1)
+                    {
+                        while (b2)
+                        {
+                            if (b3) break outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size       12 (0xc)
+              .maxstack  1
+              IL_0000:  br.s       IL_0008
+              IL_0002:  ldarg.2
+              IL_0003:  brtrue.s   IL_000b
+              IL_0005:  ldarg.1
+              IL_0006:  brtrue.s   IL_0002
+              IL_0008:  ldarg.0
+              IL_0009:  brtrue.s   IL_0005
+              IL_000b:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Continue_While_Immediate()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b)
+                {
+                    outer: while (b)
+                    {
+                        continue outer;
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size        4 (0x4)
+              .maxstack  1
+              IL_0000:  ldarg.0
+              IL_0001:  brtrue.s   IL_0000
+              IL_0003:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Continue_While_Nested()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b1, bool b2)
+                {
+                    outer: while (b1)
+                    {
+                        while (b2)
+                        {
+                            continue outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size        8 (0x8)
+              .maxstack  1
+              IL_0000:  br.s       IL_0004
+              IL_0002:  ldarg.1
+              IL_0003:  pop
+              IL_0004:  ldarg.0
+              IL_0005:  brtrue.s   IL_0002
+              IL_0007:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Continue_While_Nested_Conditional()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b1, bool b2, bool b3)
+                {
+                    outer: while (b1)
+                    {
+                        while (b2)
+                        {
+                            if (b3) continue outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size       12 (0xc)
+              .maxstack  1
+              IL_0000:  br.s       IL_0008
+              IL_0002:  ldarg.2
+              IL_0003:  brtrue.s   IL_0008
+              IL_0005:  ldarg.1
+              IL_0006:  brtrue.s   IL_0002
+              IL_0008:  ldarg.0
+              IL_0009:  brtrue.s   IL_0005
+              IL_000b:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Break_DoWhile_Nested()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b1, bool b2)
+                {
+                    outer: do
+                    {
+                        do
+                        {
+                            break outer;
+                        } while (b2);
+                    } while (b1);
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size        1 (0x1)
+              .maxstack  1
+              IL_0000:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Break_DoWhile_Nested_Conditional()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b1, bool b2, bool b3)
+                {
+                    outer: do
+                    {
+                        do
+                        {
+                            if (b3) break outer;
+                        } while (b2);
+                    } while (b1);
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size       10 (0xa)
+              .maxstack  1
+              IL_0000:  ldarg.2
+              IL_0001:  brtrue.s   IL_0009
+              IL_0003:  ldarg.1
+              IL_0004:  brtrue.s   IL_0000
+              IL_0006:  ldarg.0
+              IL_0007:  brtrue.s   IL_0000
+              IL_0009:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Continue_DoWhile_Immediate()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b)
+                {
+                    outer: do
+                    {
+                        continue outer;
+                    } while (b);
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size        4 (0x4)
+              .maxstack  1
+              IL_0000:  ldarg.0
+              IL_0001:  brtrue.s   IL_0000
+              IL_0003:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Continue_DoWhile_Nested()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b1, bool b2)
+                {
+                    outer: do
+                    {
+                        do
+                        {
+                            continue outer;
+                        } while (b2);
+                    } while (b1);
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size        4 (0x4)
+              .maxstack  1
+              IL_0000:  ldarg.0
+              IL_0001:  brtrue.s   IL_0000
+              IL_0003:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Continue_DoWhile_Nested_Conditional()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b1, bool b2, bool b3)
+                {
+                    outer: do
+                    {
+                        do
+                        {
+                            if (b3) continue outer;
+                        } while (b2);
+                    } while (b1);
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size       10 (0xa)
+              .maxstack  1
+              IL_0000:  ldarg.2
+              IL_0001:  brtrue.s   IL_0006
+              IL_0003:  ldarg.1
+              IL_0004:  brtrue.s   IL_0000
+              IL_0006:  ldarg.0
+              IL_0007:  brtrue.s   IL_0000
+              IL_0009:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Break_For_Nested()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b)
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        for (int j = 0; b; j++)
+                        {
+                            break outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size       19 (0x13)
+              .maxstack  2
+              .locals init (int V_0, //i
+                           int V_1) //j
+              IL_0000:  ldc.i4.0
+              IL_0001:  stloc.0
+              IL_0002:  br.s       IL_000d
+              IL_0004:  ldc.i4.0
+              IL_0005:  stloc.1
+              IL_0006:  ldarg.0
+              IL_0007:  brtrue.s   IL_0012
+              IL_0009:  ldloc.0
+              IL_000a:  ldc.i4.1
+              IL_000b:  add
+              IL_000c:  stloc.0
+              IL_000d:  ldloc.0
+              IL_000e:  ldc.i4.s   10
+              IL_0010:  blt.s      IL_0004
+              IL_0012:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Break_For_Nested_Conditional()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b1, bool b2)
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        for (int j = 0; b1; j++)
+                        {
+                            if (b2) break outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size       28 (0x1c)
+              .maxstack  2
+              .locals init (int V_0, //i
+                           int V_1) //j
+              IL_0000:  ldc.i4.0
+              IL_0001:  stloc.0
+              IL_0002:  br.s       IL_0016
+              IL_0004:  ldc.i4.0
+              IL_0005:  stloc.1
+              IL_0006:  br.s       IL_000f
+              IL_0008:  ldarg.1
+              IL_0009:  brtrue.s   IL_001b
+              IL_000b:  ldloc.1
+              IL_000c:  ldc.i4.1
+              IL_000d:  add
+              IL_000e:  stloc.1
+              IL_000f:  ldarg.0
+              IL_0010:  brtrue.s   IL_0008
+              IL_0012:  ldloc.0
+              IL_0013:  ldc.i4.1
+              IL_0014:  add
+              IL_0015:  stloc.0
+              IL_0016:  ldloc.0
+              IL_0017:  ldc.i4.s   10
+              IL_0019:  blt.s      IL_0004
+              IL_001b:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Continue_For_Immediate()
+    {
+        var source = """
+            class C
+            {
+                static void M()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        continue outer;
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size       14 (0xe)
+              .maxstack  2
+              .locals init (int V_0) //i
+              IL_0000:  ldc.i4.0
+              IL_0001:  stloc.0
+              IL_0002:  br.s       IL_0008
+              IL_0004:  ldloc.0
+              IL_0005:  ldc.i4.1
+              IL_0006:  add
+              IL_0007:  stloc.0
+              IL_0008:  ldloc.0
+              IL_0009:  ldc.i4.s   10
+              IL_000b:  blt.s      IL_0004
+              IL_000d:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Continue_For_Nested()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b)
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        for (int j = 0; b; j++)
+                        {
+                            continue outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size       18 (0x12)
+              .maxstack  2
+              .locals init (int V_0, //i
+                           int V_1) //j
+              IL_0000:  ldc.i4.0
+              IL_0001:  stloc.0
+              IL_0002:  br.s       IL_000c
+              IL_0004:  ldc.i4.0
+              IL_0005:  stloc.1
+              IL_0006:  ldarg.0
+              IL_0007:  pop
+              IL_0008:  ldloc.0
+              IL_0009:  ldc.i4.1
+              IL_000a:  add
+              IL_000b:  stloc.0
+              IL_000c:  ldloc.0
+              IL_000d:  ldc.i4.s   10
+              IL_000f:  blt.s      IL_0004
+              IL_0011:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Continue_For_Nested_Conditional()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b1, bool b2)
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        for (int j = 0; b1; j++)
+                        {
+                            if (b2) continue outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size       28 (0x1c)
+              .maxstack  2
+              .locals init (int V_0, //i
+                           int V_1) //j
+              IL_0000:  ldc.i4.0
+              IL_0001:  stloc.0
+              IL_0002:  br.s       IL_0016
+              IL_0004:  ldc.i4.0
+              IL_0005:  stloc.1
+              IL_0006:  br.s       IL_000f
+              IL_0008:  ldarg.1
+              IL_0009:  brtrue.s   IL_0012
+              IL_000b:  ldloc.1
+              IL_000c:  ldc.i4.1
+              IL_000d:  add
+              IL_000e:  stloc.1
+              IL_000f:  ldarg.0
+              IL_0010:  brtrue.s   IL_0008
+              IL_0012:  ldloc.0
+              IL_0013:  ldc.i4.1
+              IL_0014:  add
+              IL_0015:  stloc.0
+              IL_0016:  ldloc.0
+              IL_0017:  ldc.i4.s   10
+              IL_0019:  blt.s      IL_0004
+              IL_001b:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Break_ForEach_Nested()
+    {
+        var source = """
+            class C
+            {
+                static void M(int[] a, int[] b)
+                {
+                    outer: foreach (var x in a)
+                    {
+                        foreach (var y in b)
+                        {
+                            break outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size       38 (0x26)
+              .maxstack  2
+              .locals init (int[] V_0,
+                           int V_1,
+                           int[] V_2,
+                           int V_3)
+              IL_0000:  ldarg.0
+              IL_0001:  stloc.0
+              IL_0002:  ldc.i4.0
+              IL_0003:  stloc.1
+              IL_0004:  br.s       IL_001f
+              IL_0006:  ldloc.0
+              IL_0007:  ldloc.1
+              IL_0008:  ldelem.i4
+              IL_0009:  pop
+              IL_000a:  ldarg.1
+              IL_000b:  stloc.2
+              IL_000c:  ldc.i4.0
+              IL_000d:  stloc.3
+              IL_000e:  br.s       IL_0015
+              IL_0010:  ldloc.2
+              IL_0011:  ldloc.3
+              IL_0012:  ldelem.i4
+              IL_0013:  pop
+              IL_0014:  ret
+              IL_0015:  ldloc.3
+              IL_0016:  ldloc.2
+              IL_0017:  ldlen
+              IL_0018:  conv.i4
+              IL_0019:  blt.s      IL_0010
+              IL_001b:  ldloc.1
+              IL_001c:  ldc.i4.1
+              IL_001d:  add
+              IL_001e:  stloc.1
+              IL_001f:  ldloc.1
+              IL_0020:  ldloc.0
+              IL_0021:  ldlen
+              IL_0022:  conv.i4
+              IL_0023:  blt.s      IL_0006
+              IL_0025:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Continue_ForEach_Nested()
+    {
+        var source = """
+            class C
+            {
+                static void M(int[] a, int[] b)
+                {
+                    outer: foreach (var x in a)
+                    {
+                        foreach (var y in b)
+                        {
+                            continue outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size       39 (0x27)
+              .maxstack  2
+              .locals init (int[] V_0,
+                           int V_1,
+                           int[] V_2,
+                           int V_3)
+              IL_0000:  ldarg.0
+              IL_0001:  stloc.0
+              IL_0002:  ldc.i4.0
+              IL_0003:  stloc.1
+              IL_0004:  br.s       IL_0020
+              IL_0006:  ldloc.0
+              IL_0007:  ldloc.1
+              IL_0008:  ldelem.i4
+              IL_0009:  pop
+              IL_000a:  ldarg.1
+              IL_000b:  stloc.2
+              IL_000c:  ldc.i4.0
+              IL_000d:  stloc.3
+              IL_000e:  br.s       IL_0016
+              IL_0010:  ldloc.2
+              IL_0011:  ldloc.3
+              IL_0012:  ldelem.i4
+              IL_0013:  pop
+              IL_0014:  br.s       IL_001c
+              IL_0016:  ldloc.3
+              IL_0017:  ldloc.2
+              IL_0018:  ldlen
+              IL_0019:  conv.i4
+              IL_001a:  blt.s      IL_0010
+              IL_001c:  ldloc.1
+              IL_001d:  ldc.i4.1
+              IL_001e:  add
+              IL_001f:  stloc.1
+              IL_0020:  ldloc.1
+              IL_0021:  ldloc.0
+              IL_0022:  ldlen
+              IL_0023:  conv.i4
+              IL_0024:  blt.s      IL_0006
+              IL_0026:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Break_Switch_Immediate()
+    {
+        var source = """
+            class C
+            {
+                static void M(int x)
+                {
+                    outer: switch (x)
+                    {
+                        case 0: break outer;
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size        3 (0x3)
+              .maxstack  1
+              IL_0000:  ldarg.0
+              IL_0001:  pop
+              IL_0002:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Break_Switch_FromWhile()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b, int x)
+                {
+                    outer: while (b)
+                    {
+                        switch (x)
+                        {
+                            case 0: break outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size        9 (0x9)
+              .maxstack  1
+              IL_0000:  br.s       IL_0005
+              IL_0002:  ldarg.1
+              IL_0003:  brfalse.s  IL_0008
+              IL_0005:  ldarg.0
+              IL_0006:  brtrue.s   IL_0002
+              IL_0008:  ret
+            }
+            """);
+    }
+
+    #endregion
+}

--- a/src/Compilers/CSharp/Test/CSharp15/LabeledBreakContinueIOperationTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/LabeledBreakContinueIOperationTests.cs
@@ -1,0 +1,453 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+public sealed class LabeledBreakContinueIOperationTests : SemanticModelTestBase
+{
+    #region GetCorrespondingOperation — labeled break/continue targeting immediate construct
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledBreak_ImmediateWhile()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: while (true)
+                    {
+                        /*<bind>*/break outer;/*</bind>*/
+                    }
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<BreakStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<IWhileLoopOperation>(corresponding);
+    }
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledContinue_ImmediateWhile()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: while (true)
+                    {
+                        /*<bind>*/continue outer;/*</bind>*/
+                    }
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<ContinueStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<IWhileLoopOperation>(corresponding);
+    }
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledBreak_ImmediateFor()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        /*<bind>*/break outer;/*</bind>*/
+                    }
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<BreakStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<IForLoopOperation>(corresponding);
+    }
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledContinue_ImmediateForEach()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: foreach (var x in new[] { 1 })
+                    {
+                        /*<bind>*/continue outer;/*</bind>*/
+                    }
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<ContinueStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<IForEachLoopOperation>(corresponding);
+    }
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledBreak_ImmediateDoWhile()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: do
+                    {
+                        /*<bind>*/break outer;/*</bind>*/
+                    } while (true);
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<BreakStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<IWhileLoopOperation>(corresponding);
+    }
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledBreak_ImmediateSwitch()
+    {
+        var source = """
+            class C
+            {
+                void F(int x)
+                {
+                    outer: switch (x)
+                    {
+                        case 0:
+                            /*<bind>*/break outer;/*</bind>*/
+                    }
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<BreakStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<ISwitchOperation>(corresponding);
+    }
+
+    #endregion
+
+    #region GetCorrespondingOperation — labeled break/continue targeting outer construct (skipping inner)
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledBreak_OuterWhile_SkipsInnerWhile()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: while (true)
+                    {
+                        while (true)
+                        {
+                            /*<bind>*/break outer;/*</bind>*/
+                        }
+                    }
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<BreakStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<IWhileLoopOperation>(corresponding);
+        var whileOp = (IWhileLoopOperation)corresponding;
+        Assert.Equal("while (true)", whileOp.Syntax.ToString().Split('\n')[0].Trim());
+    }
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledContinue_OuterFor_SkipsInnerWhile()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        while (true)
+                        {
+                            /*<bind>*/continue outer;/*</bind>*/
+                        }
+                    }
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<ContinueStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<IForLoopOperation>(corresponding);
+    }
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledBreak_OuterWhile_SkipsInnerSwitch()
+    {
+        var source = """
+            class C
+            {
+                void F(int x)
+                {
+                    outer: while (true)
+                    {
+                        switch (x)
+                        {
+                            case 0:
+                                /*<bind>*/break outer;/*</bind>*/
+                        }
+                    }
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<BreakStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<IWhileLoopOperation>(corresponding);
+    }
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledBreak_OuterSwitch_SkipsInnerSwitch()
+    {
+        var source = """
+            class C
+            {
+                void F(int x)
+                {
+                    outer: switch (x)
+                    {
+                        case 0:
+                            switch (x)
+                            {
+                                case 1:
+                                    /*<bind>*/break outer;/*</bind>*/
+                            }
+                            break;
+                    }
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<BreakStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<ISwitchOperation>(corresponding);
+        var switchOp = (ISwitchOperation)corresponding;
+        Assert.Equal("x", switchOp.Value.Syntax.ToString());
+    }
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledContinue_OuterForEach_SkipsInnerFor()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: foreach (var x in new[] { 1 })
+                    {
+                        for (int i = 0; i < 10; i++)
+                        {
+                            /*<bind>*/continue outer;/*</bind>*/
+                        }
+                    }
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<ContinueStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<IForEachLoopOperation>(corresponding);
+    }
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledBreak_OuterDoWhile_SkipsInnerForEach()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: do
+                    {
+                        foreach (var x in new[] { 1 })
+                        {
+                            /*<bind>*/break outer;/*</bind>*/
+                        }
+                    } while (true);
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<BreakStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<IWhileLoopOperation>(corresponding);
+    }
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledBreak_SkipsTwoLevels()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: while (true)
+                    {
+                        for (int i = 0; i < 10; i++)
+                        {
+                            foreach (var x in new[] { 1 })
+                            {
+                                /*<bind>*/break outer;/*</bind>*/
+                            }
+                        }
+                    }
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<BreakStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<IWhileLoopOperation>(corresponding);
+    }
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledContinue_SkipsSwitchAndInnerLoop()
+    {
+        var source = """
+            class C
+            {
+                void F(int x)
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        switch (x)
+                        {
+                            case 0:
+                                while (true)
+                                {
+                                    /*<bind>*/continue outer;/*</bind>*/
+                                }
+                                break;
+                        }
+                    }
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<ContinueStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<IForLoopOperation>(corresponding);
+    }
+
+    #endregion
+
+    #region IBranchOperation properties
+
+    [Fact]
+    public void IBranchOperation_LabeledBreak_HasBreakKind()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: while (true)
+                    {
+                        break outer;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var breakSyntax = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single();
+        var operation = model.GetOperation(breakSyntax) as IBranchOperation;
+
+        Assert.NotNull(operation);
+        Assert.Equal(BranchKind.Break, operation.BranchKind);
+        Assert.NotNull(operation.Target);
+    }
+
+    [Fact]
+    public void IBranchOperation_LabeledContinue_HasContinueKind()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: while (true)
+                    {
+                        continue outer;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var continueSyntax = tree.GetRoot().DescendantNodes().OfType<ContinueStatementSyntax>().Single();
+        var operation = model.GetOperation(continueSyntax) as IBranchOperation;
+
+        Assert.NotNull(operation);
+        Assert.Equal(BranchKind.Continue, operation.BranchKind);
+        Assert.NotNull(operation.Target);
+    }
+
+    [Fact]
+    public void IBranchOperation_LabeledBreak_NestedLoop_TargetDiffersFromUnlabeled()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: while (true)
+                    {
+                        while (true)
+                        {
+                            break outer;
+                            break;
+                        }
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        comp.VerifyDiagnostics(
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(10, 17));
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var breakStmts = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().ToArray();
+        Assert.Equal(2, breakStmts.Length);
+
+        var labeledBreak = model.GetOperation(breakStmts[0]) as IBranchOperation;
+        var unlabeledBreak = model.GetOperation(breakStmts[1]) as IBranchOperation;
+
+        Assert.NotNull(labeledBreak);
+        Assert.NotNull(unlabeledBreak);
+        Assert.Equal(BranchKind.Break, labeledBreak.BranchKind);
+        Assert.Equal(BranchKind.Break, unlabeledBreak.BranchKind);
+        Assert.NotEqual(labeledBreak.Target, unlabeledBreak.Target);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private IOperation GetCorrespondingOperation<TSyntax>(string source) where TSyntax : SyntaxNode
+    {
+        var compilation = CreateCompilation(source);
+        var inner = GetOperationAndSyntaxForTest<TSyntax>(compilation).operation as IBranchOperation;
+        return inner?.GetCorrespondingOperation();
+    }
+
+    #endregion
+}

--- a/src/Compilers/CSharp/Test/CSharp15/LabeledBreakContinueSemanticModelTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/LabeledBreakContinueSemanticModelTests.cs
@@ -1,0 +1,545 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+public sealed class LabeledBreakContinueSemanticModelTests : CSharpTestBase
+{
+    #region GetSymbolInfo
+
+    [Fact]
+    public void GetSymbolInfo_Break_ResolvesToLabelSymbol()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        break outer;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var labelDecl = tree.GetRoot().DescendantNodes().OfType<LabeledStatementSyntax>().Single();
+        var declaredSymbol = model.GetDeclaredSymbol(labelDecl);
+        Assert.NotNull(declaredSymbol);
+        Assert.Equal("outer", declaredSymbol.Name);
+        Assert.Equal(SymbolKind.Label, declaredSymbol.Kind);
+
+        var breakStmt = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single();
+        var labelRef = breakStmt.Name;
+        Assert.NotNull(labelRef);
+
+        var symbolInfo = model.GetSymbolInfo(labelRef);
+        Assert.Same(declaredSymbol, symbolInfo.Symbol);
+    }
+
+    [Fact]
+    public void GetSymbolInfo_Continue_ResolvesToLabelSymbol()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        continue outer;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var labelDecl = tree.GetRoot().DescendantNodes().OfType<LabeledStatementSyntax>().Single();
+        var declaredSymbol = model.GetDeclaredSymbol(labelDecl);
+
+        var continueStmt = tree.GetRoot().DescendantNodes().OfType<ContinueStatementSyntax>().Single();
+        var labelRef = continueStmt.Name;
+        Assert.NotNull(labelRef);
+
+        var symbolInfo = model.GetSymbolInfo(labelRef);
+        Assert.Same(declaredSymbol, symbolInfo.Symbol);
+    }
+
+    [Fact]
+    public void GetSymbolInfo_Break_NestedLoop_ResolvesToOuterLabel()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        inner: while (true)
+                        {
+                            break outer;
+                        }
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var labels = tree.GetRoot().DescendantNodes().OfType<LabeledStatementSyntax>().ToArray();
+        var outerLabel = model.GetDeclaredSymbol(labels.Single(l => l.Identifier.ValueText == "outer"));
+
+        var breakStmt = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single();
+        var symbolInfo = model.GetSymbolInfo(breakStmt.Name);
+        Assert.Same(outerLabel, symbolInfo.Symbol);
+    }
+
+    [Fact]
+    public void GetSymbolInfo_UnlabeledBreak_NoName()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    while (true)
+                    {
+                        break;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+
+        var breakStmt = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single();
+        Assert.Null(breakStmt.Name);
+    }
+
+    #endregion
+
+    #region GetTypeInfo / GetConversion / GetMemberGroup / GetConstantValue / GetAliasInfo
+
+    [Fact]
+    public void GetTypeInfo_OnLabel_ReturnsNothing()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        break outer;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var breakStmt = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single();
+        var typeInfo = model.GetTypeInfo(breakStmt.Name);
+        Assert.Null(typeInfo.Type);
+        Assert.Null(typeInfo.ConvertedType);
+    }
+
+    [Fact]
+    public void GetConversion_OnLabel_ReturnsNoConversion()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        break outer;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var breakStmt = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single();
+        var conversion = model.GetConversion(breakStmt.Name);
+        Assert.True(conversion.IsIdentity);
+    }
+
+    [Fact]
+    public void GetMemberGroup_OnLabel_ReturnsEmpty()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        break outer;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var breakStmt = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single();
+        var memberGroup = model.GetMemberGroup(breakStmt.Name);
+        Assert.Empty(memberGroup);
+    }
+
+    [Fact]
+    public void GetConstantValue_OnLabel_ReturnsNothing()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        break outer;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var breakStmt = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single();
+        var constantValue = model.GetConstantValue(breakStmt.Name);
+        Assert.False(constantValue.HasValue);
+    }
+
+    [Fact]
+    public void GetAliasInfo_OnLabel_ReturnsNull()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        break outer;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var breakStmt = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single();
+        var aliasInfo = model.GetAliasInfo(breakStmt.Name);
+        Assert.Null(aliasInfo);
+    }
+
+    #endregion
+
+    #region GetDeclaredSymbol
+
+    [Fact]
+    public void GetDeclaredSymbol_OnBreakStatement_ReturnsNull()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        break outer;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var breakStmt = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single();
+        Assert.Null(model.GetDeclaredSymbol(breakStmt));
+    }
+
+    [Fact]
+    public void GetDeclaredSymbol_OnContinueStatement_ReturnsNull()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        continue outer;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var continueStmt = tree.GetRoot().DescendantNodes().OfType<ContinueStatementSyntax>().Single();
+        Assert.Null(model.GetDeclaredSymbol(continueStmt));
+    }
+
+    [Fact]
+    public void GetDeclaredSymbol_OnLabeledStatement_ReturnsLabelSymbol()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        break outer;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var labelDecl = tree.GetRoot().DescendantNodes().OfType<LabeledStatementSyntax>().Single();
+        var symbol = model.GetDeclaredSymbol(labelDecl);
+        Assert.NotNull(symbol);
+        Assert.Equal("outer", symbol.Name);
+        Assert.Equal(SymbolKind.Label, symbol.Kind);
+    }
+
+    #endregion
+
+    #region AnalyzeControlFlow
+
+    [Fact]
+    public void ControlFlow_LabeledBreak_IsExitPoint_WhenTargetOutsideRegion()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        while (true)
+                        {
+                            /*<bind>*/break outer;/*</bind>*/
+                        }
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var breakStmt = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single();
+        var controlFlow = model.AnalyzeControlFlow(breakStmt);
+
+        Assert.True(controlFlow.Succeeded);
+        Assert.Single(controlFlow.ExitPoints);
+        Assert.IsType<BreakStatementSyntax>(controlFlow.ExitPoints.Single());
+        Assert.True(controlFlow.StartPointIsReachable);
+        Assert.False(controlFlow.EndPointIsReachable);
+    }
+
+    [Fact]
+    public void ControlFlow_LabeledContinue_IsExitPoint_WhenTargetOutsideRegion()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        while (true)
+                        {
+                            /*<bind>*/continue outer;/*</bind>*/
+                        }
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var continueStmt = tree.GetRoot().DescendantNodes().OfType<ContinueStatementSyntax>().Single();
+        var controlFlow = model.AnalyzeControlFlow(continueStmt);
+
+        Assert.True(controlFlow.Succeeded);
+        Assert.Single(controlFlow.ExitPoints);
+        Assert.IsType<ContinueStatementSyntax>(controlFlow.ExitPoints.Single());
+        Assert.True(controlFlow.StartPointIsReachable);
+        Assert.False(controlFlow.EndPointIsReachable);
+    }
+
+    [Fact]
+    public void ControlFlow_LabeledBreak_NotExitPoint_WhenTargetInsideRegion()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    /*<bind>*/outer: while (true)
+                    {
+                        break outer;
+                    }/*</bind>*/
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var labelStmt = tree.GetRoot().DescendantNodes().OfType<LabeledStatementSyntax>().Single();
+        var controlFlow = model.AnalyzeControlFlow(labelStmt);
+
+        Assert.True(controlFlow.Succeeded);
+        Assert.Empty(controlFlow.ExitPoints);
+    }
+
+    [Fact]
+    public void ControlFlow_UnlabeledBreak_IsExitPoint_FromInnerLoop()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        /*<bind>*/break;/*</bind>*/
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var breakStmt = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single();
+        var controlFlow = model.AnalyzeControlFlow(breakStmt);
+
+        Assert.True(controlFlow.Succeeded);
+        Assert.Single(controlFlow.ExitPoints);
+    }
+
+    #endregion
+
+    #region AnalyzeDataFlow
+
+    [Fact]
+    public void DataFlow_LabeledBreak_VariableFlowsIn()
+    {
+        var source = """
+            class C
+            {
+                void M(bool b)
+                {
+                    int x = 0;
+                    outer: while (true)
+                    {
+                        while (true)
+                        {
+                            /*<bind>*/
+                            x++;
+                            if (b) break outer;
+                            /*</bind>*/
+                        }
+                    }
+                    System.Console.Write(x);
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var text = tree.GetText().ToString();
+        int start = text.IndexOf("/*<bind>*/") + "/*<bind>*/".Length;
+        int end = text.IndexOf("/*</bind>*/");
+
+        var stmts = tree.GetRoot().DescendantNodes().OfType<StatementSyntax>()
+            .Where(s => s.SpanStart >= start && s.Span.End <= end && s.Parent is BlockSyntax)
+            .ToArray();
+
+        var dataFlow = model.AnalyzeDataFlow(stmts.First(), stmts.Last());
+
+        Assert.True(dataFlow.Succeeded);
+        Assert.Contains(dataFlow.DataFlowsIn, s => s.Name == "x");
+        Assert.Contains(dataFlow.DataFlowsOut, s => s.Name == "x");
+        Assert.Contains(dataFlow.ReadInside, s => s.Name == "x");
+        Assert.Contains(dataFlow.WrittenInside, s => s.Name == "x");
+    }
+
+    [Fact]
+    public void DataFlow_LabeledContinue_VariableFlowsIn()
+    {
+        var source = """
+            class C
+            {
+                void M(bool b)
+                {
+                    int x = 0;
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        for (int j = 0; j < 10; j++)
+                        {
+                            /*<bind>*/
+                            x++;
+                            if (b) continue outer;
+                            /*</bind>*/
+                        }
+                    }
+                    System.Console.Write(x);
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var text = tree.GetText().ToString();
+        int start = text.IndexOf("/*<bind>*/") + "/*<bind>*/".Length;
+        int end = text.IndexOf("/*</bind>*/");
+
+        var stmts = tree.GetRoot().DescendantNodes().OfType<StatementSyntax>()
+            .Where(s => s.SpanStart >= start && s.Span.End <= end && s.Parent is BlockSyntax)
+            .ToArray();
+
+        var dataFlow = model.AnalyzeDataFlow(stmts.First(), stmts.Last());
+
+        Assert.True(dataFlow.Succeeded);
+        Assert.Contains(dataFlow.DataFlowsIn, s => s.Name == "x");
+        Assert.Contains(dataFlow.DataFlowsOut, s => s.Name == "x");
+    }
+
+    #endregion
+}

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LabeledBreakContinueBindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LabeledBreakContinueBindingTests.cs
@@ -1,0 +1,1267 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests;
+
+public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
+{
+    private static readonly CSharpParseOptions s_optionsCSharp14 =
+        TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp14);
+
+    private static readonly CSharpParseOptions s_optionsCSharp13 =
+        TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp13);
+
+    #region Valid: all loop types
+
+    [Fact]
+    public void Break_LabeledWhile()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        while (true)
+                            break outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Continue_LabeledWhile()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        while (true)
+                            continue outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Break_LabeledDoWhile()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: do
+                    {
+                        do break outer; while (true);
+                    } while (true);
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: do
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Continue_LabeledDoWhile()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: do
+                    {
+                        while (true)
+                            continue outer;
+                    } while (false);
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: do
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Break_LabeledFor()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        for (int j = 0; j < 10; j++)
+                            break outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: for (int i = 0; i < 10; i++)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
+            // (7,37): warning CS0162: Unreachable code detected
+            //             for (int j = 0; j < 10; j++)
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(7, 37));
+    }
+
+    [Fact]
+    public void Continue_LabeledFor()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        for (int j = 0; j < 10; j++)
+                            continue outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: for (int i = 0; i < 10; i++)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
+            // (7,37): warning CS0162: Unreachable code detected
+            //             for (int j = 0; j < 10; j++)
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(7, 37));
+    }
+
+    [Fact]
+    public void Break_LabeledForEach()
+    {
+        var source = """
+            class C
+            {
+                void M(string[] args)
+                {
+                    outer: foreach (var a in args)
+                    {
+                        foreach (var b in args)
+                            break outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: foreach (var a in args)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Continue_LabeledForEach()
+    {
+        var source = """
+            class C
+            {
+                void M(string[] args)
+                {
+                    outer: foreach (var a in args)
+                    {
+                        foreach (var b in args)
+                            continue outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: foreach (var a in args)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Continue_LabeledForEachDeconstruction()
+    {
+        var source = """
+            class C
+            {
+                void M((int, int)[] items)
+                {
+                    outer: foreach (var (x, y) in items)
+                    {
+                        foreach (var z in items)
+                            continue outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: foreach (var (x, y) in items)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    #endregion
+
+    #region Valid: switch
+
+    [Fact]
+    public void Break_LabeledSwitch()
+    {
+        var source = """
+            class C
+            {
+                void M(int x)
+                {
+                    outer: switch (x)
+                    {
+                        default:
+                            while (true)
+                                break outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: switch (x)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Break_LabelOnLoop_FromInsideSwitch()
+    {
+        var source = """
+            class C
+            {
+                void M(int x)
+                {
+                    outer: while (true)
+                    {
+                        switch (x)
+                        {
+                            default:
+                                break outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Break_NestedSwitches_BreakOuter()
+    {
+        var source = """
+            class C
+            {
+                void M(int x)
+                {
+                    outer: switch (x)
+                    {
+                        case 0:
+                            switch (x)
+                            {
+                                case 0: break outer;
+                            }
+                            break;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: switch (x)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    #endregion
+
+    #region Valid: nested labels
+
+    [Fact]
+    public void Break_StackedLabels()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    a: b: c: while (true)
+                    {
+                        break b;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         a: b: c: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "a").WithLocation(5, 9),
+            // (5,12): warning CS0164: This label has not been referenced
+            //         a: b: c: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "b").WithLocation(5, 12),
+            // (5,15): warning CS0164: This label has not been referenced
+            //         a: b: c: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "c").WithLocation(5, 15));
+    }
+
+    [Fact]
+    public void Break_DeeplyNested_LoopSwitchLoop()
+    {
+        var source = """
+            class C
+            {
+                void M(int a, int b)
+                {
+                    L0: while (a-- > 0)
+                    {
+                        L1: switch (b)
+                        {
+                            default:
+                                L2: while (true)
+                                {
+                                    if (a == 0) break L0;
+                                    if (b == 0) break L1;
+                                    continue L2;
+                                }
+                                break;
+                        }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         L0: while (a-- > 0)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L0").WithLocation(5, 9),
+            // (7,13): warning CS0164: This label has not been referenced
+            //             L1: switch (b)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L1").WithLocation(7, 13),
+            // (10,21): warning CS0164: This label has not been referenced
+            //                     L2: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L2").WithLocation(10, 21),
+            // (16,21): warning CS0162: Unreachable code detected
+            //                     break;
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(16, 21));
+    }
+
+    #endregion
+
+    #region Valid: interaction with other constructs
+
+    [Fact]
+    public void Break_InsideTryCatch()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        try
+                        {
+                            break outer;
+                        }
+                        catch { }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Break_InsideChecked()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        checked
+                        {
+                            break outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: for (int i = 0; i < 10; i++)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
+            // (5,40): warning CS0162: Unreachable code detected
+            //         outer: for (int i = 0; i < 10; i++)
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "i").WithLocation(5, 40));
+    }
+
+    [Fact]
+    public void Break_InsideLockUsing()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        lock (this)
+                        {
+                            using var d = default(System.IDisposable);
+                            break outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Break_PatternSwitchWithWhen()
+    {
+        var source = """
+            class C
+            {
+                void M(object o)
+                {
+                    outer: while (true)
+                    {
+                        switch (o)
+                        {
+                            case int x when x > 0:
+                                break outer;
+                            default:
+                                break;
+                        }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Continue_AsyncMethod()
+    {
+        var source = """
+            using System.Threading.Tasks;
+            class C
+            {
+                async Task M()
+                {
+                    outer: for (int i = 0; i < 1; i++)
+                    {
+                        for (int j = 0; j < 1; j++)
+                        {
+                            await Task.Yield();
+                            continue outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (6,9): warning CS0164: This label has not been referenced
+            //         outer: for (int i = 0; i < 1; i++)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(6, 9),
+            // (8,36): warning CS0162: Unreachable code detected
+            //             for (int j = 0; j < 1; j++)
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(8, 36));
+    }
+
+    [Fact]
+    public void Break_Iterator()
+    {
+        var source = """
+            using System.Collections.Generic;
+            class C
+            {
+                IEnumerable<int> M()
+                {
+                    outer: while (true)
+                    {
+                        yield return 1;
+                        break outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (6,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(6, 9));
+    }
+
+    [Fact]
+    public void Break_GotoAndLabeledBreak_SameLabel()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    L: while (true)
+                    {
+                        goto L;
+                        break L;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (8,13): warning CS0162: Unreachable code detected
+            //             break L;
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(8, 13));
+    }
+
+    [Fact]
+    public void Continue_SwitchInsideLabeledFor()
+    {
+        var source = """
+            class C
+            {
+                void M(int x)
+                {
+                    L: for (;;)
+                        switch (x)
+                        {
+                            default: continue L;
+                        }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         L: for (;;)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Break_UnicodeEscapedLabel()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    \u006Futer: while (true)
+                    {
+                        break outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         \u006Futer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, @"\u006Futer").WithLocation(5, 9));
+    }
+
+    #endregion
+
+    #region Invalid: label not found
+
+    [Fact]
+    public void Break_LabelNotFound()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    while (true)
+                        break missing;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (6,19): error CS0159: No such label 'missing' within the scope of the goto statement
+            //             break missing;
+            Diagnostic(ErrorCode.ERR_LabelNotFound, "missing").WithArguments("missing").WithLocation(6, 19));
+    }
+
+    [Fact]
+    public void Break_LabelInSiblingBlock()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    { L: while (true) { } }
+                    { break L; }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,11): warning CS0164: This label has not been referenced
+            //         { L: while (true) { } }
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 11),
+            // (6,11): warning CS0162: Unreachable code detected
+            //         { break L; }
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(6, 11),
+            // (6,17): error CS0159: No such label 'L' within the scope of the goto statement
+            //         { break L; }
+            Diagnostic(ErrorCode.ERR_LabelNotFound, "L").WithArguments("L").WithLocation(6, 17));
+    }
+
+    #endregion
+
+    #region Invalid: label not on loop/switch
+
+    [Fact]
+    public void Break_LabelOnBlock()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    L: { break L; }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         L: { break L; }
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
+            // (5,20): error CS9378: The label 'L' does not refer to a containing loop or switch statement
+            //         L: { break L; }
+            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch, "L").WithArguments("L").WithLocation(5, 20));
+    }
+
+    [Fact]
+    public void Break_LabelOnIf()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    L: if (true)
+                        break L;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         L: if (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
+            // (6,19): error CS9378: The label 'L' does not refer to a containing loop or switch statement
+            //             break L;
+            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch, "L").WithArguments("L").WithLocation(6, 19));
+    }
+
+    [Fact]
+    public void Break_LabelOnEmptyStatement()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    L: ;
+                    while (true) break L;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         L: ;
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
+            // (6,28): error CS9378: The label 'L' does not refer to a containing loop or switch statement
+            //         while (true) break L;
+            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch, "L").WithArguments("L").WithLocation(6, 28));
+    }
+
+    [Fact]
+    public void Break_LabelOnExpressionStatement()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    L: System.Console.WriteLine();
+                    if (true) break L;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         L: System.Console.WriteLine();
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
+            // (6,25): error CS9378: The label 'L' does not refer to a containing loop or switch statement
+            //         if (true) break L;
+            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch, "L").WithArguments("L").WithLocation(6, 25));
+    }
+
+    [Fact]
+    public void Break_LabelOnLocalDeclaration_SwitchExpression()
+    {
+        var source = """
+            class C
+            {
+                void M(int x)
+                {
+                    L: var y = x switch { _ => 1 };
+                    while (true) break L;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         L: var y = x switch { _ => 1 };
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
+            // (6,28): error CS9378: The label 'L' does not refer to a containing loop or switch statement
+            //         while (true) break L;
+            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch, "L").WithArguments("L").WithLocation(6, 28));
+    }
+
+    [Fact]
+    public void Break_LabelOnLock()
+    {
+        var source = """
+            class C
+            {
+                void M(object o)
+                {
+                    L: lock (o) { break L; }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         L: lock (o) { break L; }
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
+            // (5,29): error CS9378: The label 'L' does not refer to a containing loop or switch statement
+            //         L: lock (o) { break L; }
+            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch, "L").WithArguments("L").WithLocation(5, 29));
+    }
+
+    #endregion
+
+    #region Invalid: continue targeting switch
+
+    [Fact]
+    public void Continue_TargetIsSwitch()
+    {
+        var source = """
+            class C
+            {
+                void M(int x)
+                {
+                    outer: switch (x)
+                    {
+                        default: continue outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: switch (x)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
+            // (7,13): error CS8070: Control cannot fall out of switch from final case label ('default:')
+            //             default: continue outer;
+            Diagnostic(ErrorCode.ERR_SwitchFallOut, "default:").WithArguments("default:").WithLocation(7, 13),
+            // (7,31): error CS9379: The label 'outer' does not refer to a containing loop statement
+            //             default: continue outer;
+            Diagnostic(ErrorCode.ERR_LabeledContinueNotOnLoop, "outer").WithArguments("outer").WithLocation(7, 31));
+    }
+
+    #endregion
+
+    #region Invalid: label not containing
+
+    [Fact]
+    public void Break_LabelOnSiblingLoop()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (false) { }
+                    while (true) { break outer; }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: while (false) { }
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
+            // (6,30): error CS9380: The label 'outer' does not refer to a statement that contains this break or continue statement
+            //         while (true) { break outer; }
+            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotContaining, "outer").WithArguments("outer").WithLocation(6, 30));
+    }
+
+    [Fact]
+    public void Continue_LabelOnFollowingLoop()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    while (true) { continue outer; }
+                    outer: while (false) { }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,33): error CS9380: The label 'outer' does not refer to a statement that contains this break or continue statement
+            //         while (true) { continue outer; }
+            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotContaining, "outer").WithArguments("outer").WithLocation(5, 33),
+            // (6,9): warning CS0162: Unreachable code detected
+            //         outer: while (false) { }
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "outer").WithLocation(6, 9),
+            // (6,9): warning CS0164: This label has not been referenced
+            //         outer: while (false) { }
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(6, 9));
+    }
+
+    [Fact]
+    public void Break_LabelAfterBreak()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    foreach (var x in new int[0])
+                    {
+                        break outer;
+                    outer: foreach (var y in new int[0]) { }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (7,19): error CS9380: The label 'outer' does not refer to a statement that contains this break or continue statement
+            //             break outer;
+            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotContaining, "outer").WithArguments("outer").WithLocation(7, 19),
+            // (8,9): warning CS0164: This label has not been referenced
+            //         outer: foreach (var y in new int[0]) { }
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(8, 9));
+    }
+
+    [Fact]
+    public void Continue_LabelOnInnerLoop_NotContaining()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    foreach (var x in new int[0])
+                    {
+                        continue outer;
+                    outer: foreach (var y in new int[0]) { }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (7,22): error CS9380: The label 'outer' does not refer to a statement that contains this break or continue statement
+            //             continue outer;
+            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotContaining, "outer").WithArguments("outer").WithLocation(7, 22),
+            // (8,9): warning CS0164: This label has not been referenced
+            //         outer: foreach (var y in new int[0]) { }
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(8, 9));
+    }
+
+    [Fact]
+    public void Break_LabelOnDeeperNestedLoop()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    foreach (var x in new int[0])
+                    {
+                        continue outer;
+                        { outer: foreach (var y in new int[0]) { } }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (7,22): error CS0159: No such label 'outer' within the scope of the goto statement
+            //             continue outer;
+            Diagnostic(ErrorCode.ERR_LabelNotFound, "outer").WithArguments("outer").WithLocation(7, 22),
+            // (8,15): warning CS0164: This label has not been referenced
+            //             { outer: foreach (var y in new int[0]) { } }
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(8, 15));
+    }
+
+    #endregion
+
+    #region Invalid: label various illegal positions
+
+    [Fact]
+    public void Continue_LabelExistsAfterLoop()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    foreach (var x in new int[0])
+                    {
+                        continue outer;
+                    }
+                    outer: ;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (7,22): error CS9379: The label 'outer' does not refer to a containing loop statement
+            //             continue outer;
+            Diagnostic(ErrorCode.ERR_LabeledContinueNotOnLoop, "outer").WithArguments("outer").WithLocation(7, 22),
+            // (9,9): warning CS0164: This label has not been referenced
+            //         outer: ;
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(9, 9));
+    }
+
+    [Fact]
+    public void Continue_LabelBeforeLoop()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: ;
+                    foreach (var x in new int[0])
+                    {
+                        continue outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: ;
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
+            // (8,22): error CS9379: The label 'outer' does not refer to a containing loop statement
+            //             continue outer;
+            Diagnostic(ErrorCode.ERR_LabeledContinueNotOnLoop, "outer").WithArguments("outer").WithLocation(8, 22));
+    }
+
+    [Fact]
+    public void Break_LabelOnContainingForEach_InsideNestedBlock()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    foreach (var x in new int[0])
+                    {
+                        continue outer;
+                        { outer: foreach (var y in new int[0]) { } }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (7,22): error CS0159: No such label 'outer' within the scope of the goto statement
+            //             continue outer;
+            Diagnostic(ErrorCode.ERR_LabelNotFound, "outer").WithArguments("outer").WithLocation(7, 22),
+            // (8,15): warning CS0164: This label has not been referenced
+            //             { outer: foreach (var y in new int[0]) { } }
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(8, 15));
+    }
+
+    #endregion
+
+    #region Lambda and local function boundaries
+
+    [Fact]
+    public void Break_InsideLambda_LabelOutside()
+    {
+        var source = """
+            using System;
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        Action a = () => { break outer; };
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (6,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(6, 9),
+            // (8,32): error CS1632: Control cannot leave the body of an anonymous method or lambda expression
+            //             Action a = () => { break outer; };
+            Diagnostic(ErrorCode.ERR_BadDelegateLeave, "break").WithLocation(8, 32));
+    }
+
+    [Fact]
+    public void Break_InsideLocalFunction_LabelOutside()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        void F() { break outer; }
+                        F();
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
+            // (7,24): error CS1632: Control cannot leave the body of an anonymous method or lambda expression
+            //             void F() { break outer; }
+            Diagnostic(ErrorCode.ERR_BadDelegateLeave, "break").WithLocation(7, 24));
+    }
+
+    [Fact]
+    public void Break_LabelInsideLambda_BreakOutside()
+    {
+        var source = """
+            using System;
+            class C
+            {
+                void M()
+                {
+                    Action a = () => { outer: while (true) { } };
+                    break outer;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (6,28): warning CS0164: This label has not been referenced
+            //         Action a = () => { outer: while (true) { } };
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(6, 28),
+            // (7,15): error CS0159: No such label 'outer' within the scope of the goto statement
+            //         break outer;
+            Diagnostic(ErrorCode.ERR_LabelNotFound, "outer").WithArguments("outer").WithLocation(7, 15));
+    }
+
+    #endregion
+
+    #region Finally blocks
+
+    [Fact]
+    public void Break_InFinally_TargetsOuterLoop()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        try { }
+                        finally { break outer; }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: for (int i = 0; i < 10; i++)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
+            // (5,40): warning CS0162: Unreachable code detected
+            //         outer: for (int i = 0; i < 10; i++)
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "i").WithLocation(5, 40),
+            // (8,23): error CS0157: Control cannot leave the body of a finally clause
+            //             finally { break outer; }
+            Diagnostic(ErrorCode.ERR_BadFinallyLeave, "break").WithLocation(8, 23));
+    }
+
+    [Fact]
+    public void Continue_InFinally_TargetsOuterLoop()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        try { }
+                        finally { continue outer; }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: for (int i = 0; i < 10; i++)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
+            // (8,23): error CS0157: Control cannot leave the body of a finally clause
+            //             finally { continue outer; }
+            Diagnostic(ErrorCode.ERR_BadFinallyLeave, "continue").WithLocation(8, 23));
+    }
+
+    [Fact]
+    public void Break_InTryWithFinally_Valid()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        try { break outer; }
+                        finally { }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    #endregion
+
+    #region Language version gating
+
+    [Fact]
+    public void Break_CSharp13_FeatureNotAvailable()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                        break outer;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp13).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
+            // (6,19): error CS9260: Feature 'labeled break and continue' is not available in C# 13.0. Please use language version 14.0 or greater.
+            //             break outer;
+            Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion13, "outer").WithArguments("labeled break and continue", "14.0").WithLocation(6, 19));
+    }
+
+    [Fact]
+    public void Continue_CSharp13_FeatureNotAvailable()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        for (int j = 0; j < 10; j++)
+                            continue outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp13).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: for (int i = 0; i < 10; i++)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
+            // (7,37): warning CS0162: Unreachable code detected
+            //             for (int j = 0; j < 10; j++)
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(7, 37),
+            // (8,26): error CS9260: Feature 'labeled break and continue' is not available in C# 13.0. Please use language version 14.0 or greater.
+            //                 continue outer;
+            Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion13, "outer").WithArguments("labeled break and continue", "14.0").WithLocation(8, 26));
+    }
+
+    [Fact]
+    public void Break_Preview_Works()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                        break outer;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    #endregion
+
+    #region Top-level statements
+
+    [Fact]
+    public void Break_TopLevelStatements()
+    {
+        var source = """
+            outer: for (int i = 0; i < 1; i++)
+                break outer;
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+            // (1,1): warning CS0164: This label has not been referenced
+            // outer: for (int i = 0; i < 1; i++)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(1, 1),
+            // (1,31): warning CS0162: Unreachable code detected
+            // outer: for (int i = 0; i < 1; i++)
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "i").WithLocation(1, 31));
+    }
+
+    #endregion
+}

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LabeledBreakContinueBindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LabeledBreakContinueBindingTests.cs
@@ -14,9 +14,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
     private static readonly CSharpParseOptions s_optionsCSharp14 =
         TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp14);
 
-    private static readonly CSharpParseOptions s_optionsCSharp13 =
-        TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp13);
-
     #region Valid: all loop types
 
     [Fact]
@@ -35,7 +32,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -57,7 +54,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -78,7 +75,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: do
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -100,7 +97,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: do
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -122,7 +119,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: for (int i = 0; i < 10; i++)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
@@ -147,7 +144,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: for (int i = 0; i < 10; i++)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
@@ -172,7 +169,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: foreach (var a in args)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -194,7 +191,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: foreach (var a in args)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -216,7 +213,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: foreach (var (x, y) in items)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -243,7 +240,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: switch (x)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -268,7 +265,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -294,7 +291,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: switch (x)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -319,7 +316,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         a: b: c: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "a").WithLocation(5, 9),
@@ -328,7 +325,10 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "b").WithLocation(5, 12),
             // (5,15): warning CS0164: This label has not been referenced
             //         a: b: c: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "c").WithLocation(5, 15));
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "c").WithLocation(5, 15),
+            // (7,19): error CS9378: No enclosing loop or switch statement with the label 'b' out of which to break or continue
+            //             break b;
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "b").WithArguments("b").WithLocation(7, 19));
     }
 
     [Fact]
@@ -356,7 +356,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         L0: while (a-- > 0)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L0").WithLocation(5, 9),
@@ -394,7 +394,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -418,7 +418,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: for (int i = 0; i < 10; i++)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
@@ -446,7 +446,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -473,7 +473,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -499,7 +499,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (6,9): warning CS0164: This label has not been referenced
             //         outer: for (int i = 0; i < 1; i++)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(6, 9),
@@ -525,7 +525,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (6,9): warning CS0164: This label has not been referenced
             //         outer: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(6, 9));
@@ -547,7 +547,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (8,13): warning CS0162: Unreachable code detected
             //             break L;
             Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(8, 13));
@@ -569,7 +569,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         L: for (;;)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9));
@@ -590,7 +590,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         \u006Futer: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, @"\u006Futer").WithLocation(5, 9));
@@ -613,10 +613,10 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (6,19): error CS0159: No such label 'missing' within the scope of the goto statement
             //             break missing;
-            Diagnostic(ErrorCode.ERR_LabelNotFound, "missing").WithArguments("missing").WithLocation(6, 19));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "missing").WithArguments("missing").WithLocation(6, 19));
     }
 
     [Fact]
@@ -632,7 +632,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,11): warning CS0164: This label has not been referenced
             //         { L: while (true) { } }
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 11),
@@ -641,7 +641,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(6, 11),
             // (6,17): error CS0159: No such label 'L' within the scope of the goto statement
             //         { break L; }
-            Diagnostic(ErrorCode.ERR_LabelNotFound, "L").WithArguments("L").WithLocation(6, 17));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "L").WithArguments("L").WithLocation(6, 17));
     }
 
     #endregion
@@ -660,13 +660,13 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         L: { break L; }
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
             // (5,20): error CS9378: The label 'L' does not refer to a containing loop or switch statement
             //         L: { break L; }
-            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch, "L").WithArguments("L").WithLocation(5, 20));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "L").WithArguments("L").WithLocation(5, 20));
     }
 
     [Fact]
@@ -682,13 +682,13 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         L: if (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
             // (6,19): error CS9378: The label 'L' does not refer to a containing loop or switch statement
             //             break L;
-            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch, "L").WithArguments("L").WithLocation(6, 19));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "L").WithArguments("L").WithLocation(6, 19));
     }
 
     [Fact]
@@ -704,13 +704,13 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         L: ;
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
             // (6,28): error CS9378: The label 'L' does not refer to a containing loop or switch statement
             //         while (true) break L;
-            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch, "L").WithArguments("L").WithLocation(6, 28));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "L").WithArguments("L").WithLocation(6, 28));
     }
 
     [Fact]
@@ -726,13 +726,13 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         L: System.Console.WriteLine();
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
             // (6,25): error CS9378: The label 'L' does not refer to a containing loop or switch statement
             //         if (true) break L;
-            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch, "L").WithArguments("L").WithLocation(6, 25));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "L").WithArguments("L").WithLocation(6, 25));
     }
 
     [Fact]
@@ -748,13 +748,13 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         L: var y = x switch { _ => 1 };
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
             // (6,28): error CS9378: The label 'L' does not refer to a containing loop or switch statement
             //         while (true) break L;
-            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch, "L").WithArguments("L").WithLocation(6, 28));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "L").WithArguments("L").WithLocation(6, 28));
     }
 
     [Fact]
@@ -769,13 +769,13 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         L: lock (o) { break L; }
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
             // (5,29): error CS9378: The label 'L' does not refer to a containing loop or switch statement
             //         L: lock (o) { break L; }
-            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch, "L").WithArguments("L").WithLocation(5, 29));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "L").WithArguments("L").WithLocation(5, 29));
     }
 
     #endregion
@@ -797,7 +797,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: switch (x)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
@@ -806,7 +806,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             Diagnostic(ErrorCode.ERR_SwitchFallOut, "default:").WithArguments("default:").WithLocation(7, 13),
             // (7,31): error CS9379: The label 'outer' does not refer to a containing loop statement
             //             default: continue outer;
-            Diagnostic(ErrorCode.ERR_LabeledContinueNotOnLoop, "outer").WithArguments("outer").WithLocation(7, 31));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "outer").WithArguments("outer").WithLocation(7, 31));
     }
 
     #endregion
@@ -826,13 +826,13 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: while (false) { }
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
             // (6,30): error CS9380: The label 'outer' does not refer to a statement that contains this break or continue statement
             //         while (true) { break outer; }
-            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotContaining, "outer").WithArguments("outer").WithLocation(6, 30));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "outer").WithArguments("outer").WithLocation(6, 30));
     }
 
     [Fact]
@@ -848,10 +848,10 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,33): error CS9380: The label 'outer' does not refer to a statement that contains this break or continue statement
             //         while (true) { continue outer; }
-            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotContaining, "outer").WithArguments("outer").WithLocation(5, 33),
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "outer").WithArguments("outer").WithLocation(5, 33),
             // (6,9): warning CS0162: Unreachable code detected
             //         outer: while (false) { }
             Diagnostic(ErrorCode.WRN_UnreachableCode, "outer").WithLocation(6, 9),
@@ -876,10 +876,10 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (7,19): error CS9380: The label 'outer' does not refer to a statement that contains this break or continue statement
             //             break outer;
-            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotContaining, "outer").WithArguments("outer").WithLocation(7, 19),
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "outer").WithArguments("outer").WithLocation(7, 19),
             // (8,9): warning CS0164: This label has not been referenced
             //         outer: foreach (var y in new int[0]) { }
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(8, 9));
@@ -901,10 +901,10 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (7,22): error CS9380: The label 'outer' does not refer to a statement that contains this break or continue statement
             //             continue outer;
-            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotContaining, "outer").WithArguments("outer").WithLocation(7, 22),
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "outer").WithArguments("outer").WithLocation(7, 22),
             // (8,9): warning CS0164: This label has not been referenced
             //         outer: foreach (var y in new int[0]) { }
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(8, 9));
@@ -926,10 +926,10 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (7,22): error CS0159: No such label 'outer' within the scope of the goto statement
             //             continue outer;
-            Diagnostic(ErrorCode.ERR_LabelNotFound, "outer").WithArguments("outer").WithLocation(7, 22),
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "outer").WithArguments("outer").WithLocation(7, 22),
             // (8,15): warning CS0164: This label has not been referenced
             //             { outer: foreach (var y in new int[0]) { } }
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(8, 15));
@@ -955,10 +955,10 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (7,22): error CS9379: The label 'outer' does not refer to a containing loop statement
             //             continue outer;
-            Diagnostic(ErrorCode.ERR_LabeledContinueNotOnLoop, "outer").WithArguments("outer").WithLocation(7, 22),
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "outer").WithArguments("outer").WithLocation(7, 22),
             // (9,9): warning CS0164: This label has not been referenced
             //         outer: ;
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(9, 9));
@@ -980,13 +980,13 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: ;
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
             // (8,22): error CS9379: The label 'outer' does not refer to a containing loop statement
             //             continue outer;
-            Diagnostic(ErrorCode.ERR_LabeledContinueNotOnLoop, "outer").WithArguments("outer").WithLocation(8, 22));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "outer").WithArguments("outer").WithLocation(8, 22));
     }
 
     [Fact]
@@ -1005,10 +1005,10 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (7,22): error CS0159: No such label 'outer' within the scope of the goto statement
             //             continue outer;
-            Diagnostic(ErrorCode.ERR_LabelNotFound, "outer").WithArguments("outer").WithLocation(7, 22),
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "outer").WithArguments("outer").WithLocation(7, 22),
             // (8,15): warning CS0164: This label has not been referenced
             //             { outer: foreach (var y in new int[0]) { } }
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(8, 15));
@@ -1034,7 +1034,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (6,9): warning CS0164: This label has not been referenced
             //         outer: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(6, 9),
@@ -1059,13 +1059,13 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
-            // (7,24): error CS1632: Control cannot leave the body of an anonymous method or lambda expression
+            // (7,30): error CS9378: No enclosing loop or switch statement with the label 'outer' out of which to break or continue
             //             void F() { break outer; }
-            Diagnostic(ErrorCode.ERR_BadDelegateLeave, "break").WithLocation(7, 24));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "outer").WithArguments("outer").WithLocation(7, 30));
     }
 
     [Fact]
@@ -1082,13 +1082,13 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (6,28): warning CS0164: This label has not been referenced
             //         Action a = () => { outer: while (true) { } };
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(6, 28),
             // (7,15): error CS0159: No such label 'outer' within the scope of the goto statement
             //         break outer;
-            Diagnostic(ErrorCode.ERR_LabelNotFound, "outer").WithArguments("outer").WithLocation(7, 15));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "outer").WithArguments("outer").WithLocation(7, 15));
     }
 
     #endregion
@@ -1111,7 +1111,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: for (int i = 0; i < 10; i++)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
@@ -1139,7 +1139,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: for (int i = 0; i < 10; i++)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
@@ -1164,7 +1164,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -1175,7 +1175,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
     #region Language version gating
 
     [Fact]
-    public void Break_CSharp13_FeatureNotAvailable()
+    public void Break_CSharp14_FeatureInPreview()
     {
         var source = """
             class C
@@ -1187,17 +1187,17 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp13).VerifyDiagnostics(
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
-            // (6,19): error CS9260: Feature 'labeled break and continue' is not available in C# 13.0. Please use language version 14.0 or greater.
+            // (6,19): error CS8652: The feature 'labeled break and continue' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //             break outer;
-            Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion13, "outer").WithArguments("labeled break and continue", "14.0").WithLocation(6, 19));
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "outer").WithArguments("labeled break and continue").WithLocation(6, 19));
     }
 
     [Fact]
-    public void Continue_CSharp13_FeatureNotAvailable()
+    public void Continue_CSharp14_FeatureInPreview()
     {
         var source = """
             class C
@@ -1212,35 +1212,16 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp13).VerifyDiagnostics(
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: for (int i = 0; i < 10; i++)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
             // (7,37): warning CS0162: Unreachable code detected
             //             for (int j = 0; j < 10; j++)
             Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(7, 37),
-            // (8,26): error CS9260: Feature 'labeled break and continue' is not available in C# 13.0. Please use language version 14.0 or greater.
+            // (8,26): error CS8652: The feature 'labeled break and continue' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //                 continue outer;
-            Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion13, "outer").WithArguments("labeled break and continue", "14.0").WithLocation(8, 26));
-    }
-
-    [Fact]
-    public void Break_Preview_Works()
-    {
-        var source = """
-            class C
-            {
-                void M()
-                {
-                    outer: while (true)
-                        break outer;
-                }
-            }
-            """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "outer").WithArguments("labeled break and continue").WithLocation(8, 26));
     }
 
     #endregion
@@ -1254,7 +1235,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             outer: for (int i = 0; i < 1; i++)
                 break outer;
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
             // (1,1): warning CS0164: This label has not been referenced
             // outer: for (int i = 0; i < 1; i++)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(1, 1),

--- a/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
@@ -377,10 +377,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             => InternalSyntaxFactory.GotoStatement(SyntaxKind.GotoStatement, new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.AttributeListSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.GotoKeyword), null, null, InternalSyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
         private static Syntax.InternalSyntax.BreakStatementSyntax GenerateBreakStatement()
-            => InternalSyntaxFactory.BreakStatement(new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.AttributeListSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.BreakKeyword), InternalSyntaxFactory.Token(SyntaxKind.SemicolonToken));
+            => InternalSyntaxFactory.BreakStatement(new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.AttributeListSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.BreakKeyword), null, InternalSyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
         private static Syntax.InternalSyntax.ContinueStatementSyntax GenerateContinueStatement()
-            => InternalSyntaxFactory.ContinueStatement(new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.AttributeListSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.ContinueKeyword), InternalSyntaxFactory.Token(SyntaxKind.SemicolonToken));
+            => InternalSyntaxFactory.ContinueStatement(new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.AttributeListSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.ContinueKeyword), null, InternalSyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
         private static Syntax.InternalSyntax.ReturnStatementSyntax GenerateReturnStatement()
             => InternalSyntaxFactory.ReturnStatement(new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.AttributeListSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.ReturnKeyword), null, InternalSyntaxFactory.Token(SyntaxKind.SemicolonToken));
@@ -2208,6 +2208,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(default, node.AttributeLists);
             Assert.Equal(SyntaxKind.BreakKeyword, node.BreakKeyword.Kind);
+            Assert.Null(node.Name);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind);
 
             AttachAndCheckDiagnostics(node);
@@ -2220,6 +2221,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(default, node.AttributeLists);
             Assert.Equal(SyntaxKind.ContinueKeyword, node.ContinueKeyword.Kind);
+            Assert.Null(node.Name);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind);
 
             AttachAndCheckDiagnostics(node);
@@ -10767,10 +10769,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             => SyntaxFactory.GotoStatement(SyntaxKind.GotoStatement, new SyntaxList<AttributeListSyntax>(), SyntaxFactory.Token(SyntaxKind.GotoKeyword), default(SyntaxToken), default(ExpressionSyntax), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
         private static BreakStatementSyntax GenerateBreakStatement()
-            => SyntaxFactory.BreakStatement(new SyntaxList<AttributeListSyntax>(), SyntaxFactory.Token(SyntaxKind.BreakKeyword), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+            => SyntaxFactory.BreakStatement(new SyntaxList<AttributeListSyntax>(), SyntaxFactory.Token(SyntaxKind.BreakKeyword), default(IdentifierNameSyntax), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
         private static ContinueStatementSyntax GenerateContinueStatement()
-            => SyntaxFactory.ContinueStatement(new SyntaxList<AttributeListSyntax>(), SyntaxFactory.Token(SyntaxKind.ContinueKeyword), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+            => SyntaxFactory.ContinueStatement(new SyntaxList<AttributeListSyntax>(), SyntaxFactory.Token(SyntaxKind.ContinueKeyword), default(IdentifierNameSyntax), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
         private static ReturnStatementSyntax GenerateReturnStatement()
             => SyntaxFactory.ReturnStatement(new SyntaxList<AttributeListSyntax>(), SyntaxFactory.Token(SyntaxKind.ReturnKeyword), default(ExpressionSyntax), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
@@ -12598,8 +12600,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(default, node.AttributeLists);
             Assert.Equal(SyntaxKind.BreakKeyword, node.BreakKeyword.Kind());
+            Assert.Null(node.Name);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind());
-            var newNode = node.WithAttributeLists(node.AttributeLists).WithBreakKeyword(node.BreakKeyword).WithSemicolonToken(node.SemicolonToken);
+            var newNode = node.WithAttributeLists(node.AttributeLists).WithBreakKeyword(node.BreakKeyword).WithName(node.Name).WithSemicolonToken(node.SemicolonToken);
             Assert.Equal(node, newNode);
         }
 
@@ -12610,8 +12613,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(default, node.AttributeLists);
             Assert.Equal(SyntaxKind.ContinueKeyword, node.ContinueKeyword.Kind());
+            Assert.Null(node.Name);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind());
-            var newNode = node.WithAttributeLists(node.AttributeLists).WithContinueKeyword(node.ContinueKeyword).WithSemicolonToken(node.SemicolonToken);
+            var newNode = node.WithAttributeLists(node.AttributeLists).WithContinueKeyword(node.ContinueKeyword).WithName(node.Name).WithSemicolonToken(node.SemicolonToken);
             Assert.Equal(node, newNode);
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LabeledBreakContinueParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LabeledBreakContinueParsingTests.cs
@@ -1,0 +1,1084 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests;
+
+public sealed class LabeledBreakContinueParsingTests : ParsingTests
+{
+    public LabeledBreakContinueParsingTests(ITestOutputHelper output) : base(output) { }
+
+    #region Valid labeled forms
+
+    [Fact]
+    public void LabeledBreak()
+    {
+        UsingStatement("break myLabel;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "myLabel");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void LabeledContinue()
+    {
+        UsingStatement("continue myLabel;");
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "myLabel");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void UnlabeledBreak()
+    {
+        UsingStatement("break;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void UnlabeledContinue()
+    {
+        UsingStatement("continue;");
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void LabeledBreak_EscapedKeyword()
+    {
+        UsingStatement("break @class;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "@class");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void LabeledContinue_EscapedKeyword()
+    {
+        UsingStatement("continue @while;");
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "@while");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    #endregion
+
+    #region Contextual keywords as labels
+
+    [Fact]
+    public void Break_AwaitAsLabel()
+    {
+        UsingStatement("break await;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "await");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Continue_AwaitAsLabel()
+    {
+        UsingStatement("continue await;");
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "await");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_AwaitAsLabel_InsideAsyncMethod()
+    {
+        UsingDeclaration("""
+            async void M()
+            {
+                while (true)
+                {
+                    break await;
+                }
+            }
+            """,
+            options: null,
+            // (5,15): error CS4003: 'await' cannot be used as an identifier within an async method or lambda expression
+            //             break await;
+            Diagnostic(ErrorCode.ERR_BadAwaitAsIdentifier, "await").WithLocation(5, 15));
+        N(SyntaxKind.MethodDeclaration);
+        {
+            N(SyntaxKind.AsyncKeyword);
+            N(SyntaxKind.PredefinedType);
+            {
+                N(SyntaxKind.VoidKeyword);
+            }
+            N(SyntaxKind.IdentifierToken, "M");
+            N(SyntaxKind.ParameterList);
+            {
+                N(SyntaxKind.OpenParenToken);
+                N(SyntaxKind.CloseParenToken);
+            }
+            N(SyntaxKind.Block);
+            {
+                N(SyntaxKind.OpenBraceToken);
+                N(SyntaxKind.WhileStatement);
+                {
+                    N(SyntaxKind.WhileKeyword);
+                    N(SyntaxKind.OpenParenToken);
+                    N(SyntaxKind.TrueLiteralExpression);
+                    {
+                        N(SyntaxKind.TrueKeyword);
+                    }
+                    N(SyntaxKind.CloseParenToken);
+                    N(SyntaxKind.Block);
+                    {
+                        N(SyntaxKind.OpenBraceToken);
+                        N(SyntaxKind.BreakStatement);
+                        {
+                            N(SyntaxKind.BreakKeyword);
+                            N(SyntaxKind.IdentifierName);
+                            {
+                                N(SyntaxKind.IdentifierToken, "await");
+                            }
+                            N(SyntaxKind.SemicolonToken);
+                        }
+                        N(SyntaxKind.CloseBraceToken);
+                    }
+                }
+                N(SyntaxKind.CloseBraceToken);
+            }
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_AsyncAsLabel()
+    {
+        UsingStatement("break async;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "async");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_VarAsLabel()
+    {
+        UsingStatement("break var;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "var");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_FieldAsLabel()
+    {
+        UsingStatement("break field;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "field");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_ValueAsLabel()
+    {
+        UsingStatement("break value;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "value");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [InlineData("yield")]
+    [InlineData("partial")]
+    [InlineData("from")]
+    [InlineData("group")]
+    [InlineData("join")]
+    [InlineData("into")]
+    [InlineData("let")]
+    [InlineData("by")]
+    [InlineData("where")]
+    [InlineData("select")]
+    [InlineData("get")]
+    [InlineData("set")]
+    [InlineData("add")]
+    [InlineData("remove")]
+    [InlineData("orderby")]
+    [InlineData("alias")]
+    [InlineData("on")]
+    [InlineData("equals")]
+    [InlineData("ascending")]
+    [InlineData("descending")]
+    [InlineData("assembly")]
+    [InlineData("module")]
+    [InlineData("type")]
+    [InlineData("global")]
+    [InlineData("method")]
+    [InlineData("param")]
+    [InlineData("property")]
+    [InlineData("typevar")]
+    [InlineData("nameof")]
+    [InlineData("when")]
+    [InlineData("or")]
+    [InlineData("and")]
+    [InlineData("not")]
+    [InlineData("with")]
+    [InlineData("init")]
+    [InlineData("record")]
+    [InlineData("managed")]
+    [InlineData("unmanaged")]
+    [InlineData("required")]
+    [InlineData("scoped")]
+    [InlineData("file")]
+    [InlineData("allows")]
+    [InlineData("extension")]
+    [InlineData("union")]
+    public void Break_ContextualKeywordAsLabel(string keyword)
+    {
+        UsingStatement($"break {keyword};");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, keyword);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Theory]
+    [InlineData("yield")]
+    [InlineData("partial")]
+    [InlineData("from")]
+    [InlineData("group")]
+    [InlineData("join")]
+    [InlineData("into")]
+    [InlineData("let")]
+    [InlineData("by")]
+    [InlineData("where")]
+    [InlineData("select")]
+    [InlineData("get")]
+    [InlineData("set")]
+    [InlineData("add")]
+    [InlineData("remove")]
+    [InlineData("orderby")]
+    [InlineData("alias")]
+    [InlineData("on")]
+    [InlineData("equals")]
+    [InlineData("ascending")]
+    [InlineData("descending")]
+    [InlineData("assembly")]
+    [InlineData("module")]
+    [InlineData("type")]
+    [InlineData("global")]
+    [InlineData("method")]
+    [InlineData("param")]
+    [InlineData("property")]
+    [InlineData("typevar")]
+    [InlineData("nameof")]
+    [InlineData("when")]
+    [InlineData("or")]
+    [InlineData("and")]
+    [InlineData("not")]
+    [InlineData("with")]
+    [InlineData("init")]
+    [InlineData("record")]
+    [InlineData("managed")]
+    [InlineData("unmanaged")]
+    [InlineData("required")]
+    [InlineData("scoped")]
+    [InlineData("file")]
+    [InlineData("allows")]
+    [InlineData("extension")]
+    [InlineData("union")]
+    public void Continue_ContextualKeywordAsLabel(string keyword)
+    {
+        UsingStatement($"continue {keyword};");
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, keyword);
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_YieldAsLabel_ConsumedAsLabel()
+    {
+        UsingStatement("break yield;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "yield");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_WhereAsLabel_NotGenericConstraintContext()
+    {
+        UsingStatement("break where;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "where");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_PartialAsLabel_NotPartialTypePosition()
+    {
+        UsingStatement("break partial;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "partial");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_FromAsLabel_NotInQuery()
+    {
+        UsingStatement("break from;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "from");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_DynamicAsLabel()
+    {
+        UsingStatement("break dynamic;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "dynamic");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void LabeledBreak_EscapedAwait()
+    {
+        UsingStatement("break @await;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "@await");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void LabeledBreak_EscapedVar()
+    {
+        UsingStatement("break @var;");
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "@var");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void LabeledContinue_EscapedYield()
+    {
+        UsingStatement("continue @yield;");
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "@yield");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    #endregion
+
+    #region Non-identifier tokens after break/continue
+
+    [Fact]
+    public void Break_NumericLiteral()
+    {
+        UsingStatement("break 0;",
+            // (1,1): error CS1073: Unexpected token '0'
+            // break 0;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break ").WithArguments("0").WithLocation(1, 1),
+            // (1,7): error CS1002: ; expected
+            // break 0;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "0").WithLocation(1, 7));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Continue_NumericLiteral()
+    {
+        UsingStatement("continue 0;",
+            // (1,1): error CS1073: Unexpected token '0'
+            // continue 0;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "continue ").WithArguments("0").WithLocation(1, 1),
+            // (1,10): error CS1002: ; expected
+            // continue 0;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "0").WithLocation(1, 10));
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_CaseKeyword()
+    {
+        UsingStatement("break case;",
+            // (1,1): error CS1073: Unexpected token 'case'
+            // break case;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break ").WithArguments("case").WithLocation(1, 1),
+            // (1,7): error CS1002: ; expected
+            // break case;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "case").WithLocation(1, 7));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_ReturnKeyword()
+    {
+        UsingStatement("break return;",
+            // (1,1): error CS1073: Unexpected token 'return'
+            // break return;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break ").WithArguments("return").WithLocation(1, 1),
+            // (1,7): error CS1002: ; expected
+            // break return;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "return").WithLocation(1, 7));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_IntKeyword()
+    {
+        UsingStatement("break int;",
+            // (1,1): error CS1073: Unexpected token 'int'
+            // break int;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break ").WithArguments("int").WithLocation(1, 1),
+            // (1,7): error CS1002: ; expected
+            // break int;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "int").WithLocation(1, 7));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_BreakKeyword()
+    {
+        UsingStatement("break break a;",
+            // (1,1): error CS1073: Unexpected token 'break'
+            // break break a;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break ").WithArguments("break").WithLocation(1, 1),
+            // (1,7): error CS1002: ; expected
+            // break break a;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "break").WithLocation(1, 7));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_ContinueKeyword()
+    {
+        UsingStatement("break continue a;",
+            // (1,1): error CS1073: Unexpected token 'continue'
+            // break continue a;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break ").WithArguments("continue").WithLocation(1, 1),
+            // (1,7): error CS1002: ; expected
+            // break continue a;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "continue").WithLocation(1, 7));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Continue_ContinueKeyword()
+    {
+        UsingStatement("continue continue a;",
+            // (1,1): error CS1073: Unexpected token 'continue'
+            // continue continue a;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "continue ").WithArguments("continue").WithLocation(1, 1),
+            // (1,10): error CS1002: ; expected
+            // continue continue a;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "continue").WithLocation(1, 10));
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Continue_BreakKeyword()
+    {
+        UsingStatement("continue break a;",
+            // (1,1): error CS1073: Unexpected token 'break'
+            // continue break a;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "continue ").WithArguments("break").WithLocation(1, 1),
+            // (1,10): error CS1002: ; expected
+            // continue break a;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "break").WithLocation(1, 10));
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Continue_CaseKeyword()
+    {
+        UsingStatement("continue case;",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "continue ").WithArguments("case").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "case").WithLocation(1, 10));
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Continue_ReturnKeyword()
+    {
+        UsingStatement("continue return;",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "continue ").WithArguments("return").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "return").WithLocation(1, 10));
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Continue_IntKeyword()
+    {
+        UsingStatement("continue int;",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "continue ").WithArguments("int").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "int").WithLocation(1, 10));
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_ThisKeyword()
+    {
+        UsingStatement("break this;",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break ").WithArguments("this").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "this").WithLocation(1, 7));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_NullKeyword()
+    {
+        UsingStatement("break null;",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break ").WithArguments("null").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "null").WithLocation(1, 7));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_TrueKeyword()
+    {
+        UsingStatement("break true;",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break ").WithArguments("true").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "true").WithLocation(1, 7));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_FalseKeyword()
+    {
+        UsingStatement("break false;",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break ").WithArguments("false").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "false").WithLocation(1, 7));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_ParenthesizedExpression()
+    {
+        UsingStatement("break (a);",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break ").WithArguments("(").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "(").WithLocation(1, 7));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_StringLiteral()
+    {
+        UsingStatement("""break "label";""",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break ").WithArguments(@"""label""").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, @"""label""").WithLocation(1, 7));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    #endregion
+
+    #region Expressions after break/continue (only simple identifier consumed)
+
+    [Fact]
+    public void Break_ExpressionNotConsumed()
+    {
+        UsingStatement("break a + b;",
+            // (1,1): error CS1073: Unexpected token '+'
+            // break a + b;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break a ").WithArguments("+").WithLocation(1, 1),
+            // (1,9): error CS1002: ; expected
+            // break a + b;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "+").WithLocation(1, 9));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "a");
+            }
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Continue_ExpressionNotConsumed()
+    {
+        UsingStatement("continue a + b;",
+            // (1,1): error CS1073: Unexpected token '+'
+            // continue a + b;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "continue a ").WithArguments("+").WithLocation(1, 1),
+            // (1,12): error CS1002: ; expected
+            // continue a + b;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "+").WithLocation(1, 12));
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "a");
+            }
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_DottedNameNotConsumed()
+    {
+        UsingStatement("break a.b;",
+            // (1,1): error CS1073: Unexpected token '.'
+            // break a.b;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break a").WithArguments(".").WithLocation(1, 1),
+            // (1,8): error CS1002: ; expected
+            // break a.b;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, ".").WithLocation(1, 8));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "a");
+            }
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Continue_DottedNameNotConsumed()
+    {
+        UsingStatement("continue a.b;",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "continue a").WithArguments(".").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, ".").WithLocation(1, 11));
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "a");
+            }
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Continue_DottedNameMultipleMembersNotConsumed()
+    {
+        UsingStatement("continue a.b.c;",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "continue a").WithArguments(".").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, ".").WithLocation(1, 11));
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "a");
+            }
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_ExtraIdentifierAfterLabel()
+    {
+        UsingStatement("break a b;",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break a ").WithArguments("b").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "b").WithLocation(1, 9));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "a");
+            }
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Continue_ExtraIdentifierAfterLabel()
+    {
+        UsingStatement("continue a b;",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "continue a ").WithArguments("b").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "b").WithLocation(1, 12));
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "a");
+            }
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void Break_LabelFollowedByOpenBrace()
+    {
+        UsingStatement("break a {",
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "break a ").WithArguments("{").WithLocation(1, 1),
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "{").WithLocation(1, 9));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "a");
+            }
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    #endregion
+
+    #region Missing semicolon
+
+    [Fact]
+    public void LabeledBreak_MissingSemicolon()
+    {
+        UsingStatement("break myLabel",
+            // (1,14): error CS1002: ; expected
+            // break myLabel
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(1, 14));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "myLabel");
+            }
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void LabeledContinue_MissingSemicolon()
+    {
+        UsingStatement("continue myLabel",
+            // (1,17): error CS1002: ; expected
+            // continue myLabel
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(1, 17));
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "myLabel");
+            }
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    #endregion
+
+    #region yield break not affected
+
+    [Fact]
+    public void YieldBreak_NotAffected()
+    {
+        UsingStatement("yield break;");
+        N(SyntaxKind.YieldBreakStatement);
+        {
+            N(SyntaxKind.YieldKeyword);
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Fact]
+    public void YieldBreak_WithIdentifier()
+    {
+        // `yield break a;` still parses as YieldBreakStatement. The `a` is unconsumed.
+        UsingStatement("yield break a;",
+            // (1,1): error CS1073: Unexpected token 'a'
+            // yield break a;
+            Diagnostic(ErrorCode.ERR_UnexpectedToken, "yield break ").WithArguments("a").WithLocation(1, 1),
+            // (1,13): error CS1002: ; expected
+            // yield break a;
+            Diagnostic(ErrorCode.ERR_SemicolonExpected, "a").WithLocation(1, 13));
+        N(SyntaxKind.YieldBreakStatement);
+        {
+            N(SyntaxKind.YieldKeyword);
+            N(SyntaxKind.BreakKeyword);
+            M(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    #endregion
+
+    #region Language version agnostic
+
+    [Theory, CombinatorialData]
+    public void LabeledBreak_AllLanguageVersions(LanguageVersion version)
+    {
+        UsingStatement("break myLabel;", TestOptions.Regular.WithLanguageVersion(version));
+        N(SyntaxKind.BreakStatement);
+        {
+            N(SyntaxKind.BreakKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "myLabel");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    [Theory, CombinatorialData]
+    public void LabeledContinue_AllLanguageVersions(LanguageVersion version)
+    {
+        UsingStatement("continue myLabel;", TestOptions.Regular.WithLanguageVersion(version));
+        N(SyntaxKind.ContinueStatement);
+        {
+            N(SyntaxKind.ContinueKeyword);
+            N(SyntaxKind.IdentifierName);
+            {
+                N(SyntaxKind.IdentifierToken, "myLabel");
+            }
+            N(SyntaxKind.SemicolonToken);
+        }
+        EOF();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Adds semantic analysis for labeled break/continue:

- Resolves labels via LabelsOnly lookup, validates target is a containing loop (or switch for break), wires up to the correct LoopBinder/SwitchBinder labels
- Gates the feature on C# 14
- New error codes for invalid label targets and containment violations
- Fixes debug assertion in MethodCompiler to skip labeled break/continue name nodes

Stacked on syntax-parsing.