### PR TITLE
Add Go To Definition tests for labeled break/continue

### DIFF
--- a/src/Features/CSharp/Portable/GoToDefinition/CSharpGoToDefinitionSymbolService.cs
+++ b/src/Features/CSharp/Portable/GoToDefinition/CSharpGoToDefinitionSymbolService.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Composition;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -31,24 +30,14 @@ internal sealed class CSharpGoToDefinitionSymbolService() : AbstractGoToDefiniti
 
         switch (token.Kind())
         {
-            case SyntaxKind.ContinueKeyword:
-                var foundContinuedLoop = TryFindContinuableConstruct(node);
-
-                return foundContinuedLoop?.IsContinuableConstruct() == true
-                    ? foundContinuedLoop.GetFirstToken().Span.Start
-                    : null;
-
             case SyntaxKind.BreakKeyword:
                 if (token.GetPreviousToken().IsKind(SyntaxKind.YieldKeyword))
-                {
                     goto case SyntaxKind.YieldKeyword;
-                }
 
-                var foundBrokenLoop = TryFindBreakableConstruct(node);
+                return GetBreakOrContinueTargetPosition(semanticModel, node, isBreak: true);
 
-                return foundBrokenLoop?.IsBreakableConstruct() == true
-                    ? foundBrokenLoop.GetLastToken().Span.End
-                    : null;
+            case SyntaxKind.ContinueKeyword:
+                return GetBreakOrContinueTargetPosition(semanticModel, node, isBreak: false);
 
             case SyntaxKind.YieldKeyword:
             case SyntaxKind.ReturnKeyword:
@@ -79,7 +68,6 @@ internal sealed class CSharpGoToDefinitionSymbolService() : AbstractGoToDefiniti
                     if (semanticModel.GetOperation(gotoStatement) is not IBranchOperation gotoOperation)
                         return null;
 
-                    Debug.Assert(gotoOperation is { BranchKind: BranchKind.GoTo });
                     var target = gotoOperation.Target;
                     return target.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()?.SpanStart;
                 }
@@ -87,38 +75,18 @@ internal sealed class CSharpGoToDefinitionSymbolService() : AbstractGoToDefiniti
 
         return null;
 
-        static SyntaxNode? TryFindContinuableConstruct(SyntaxNode? node)
+        static int? GetBreakOrContinueTargetPosition(SemanticModel semanticModel, SyntaxNode node, bool isBreak)
         {
-            while (node is not null && !node.IsContinuableConstruct())
-            {
-                var kind = node.Kind();
+            if (semanticModel.GetOperation(node) is not IBranchOperation branchOperation)
+                return null;
 
-                if (node.IsReturnableConstruct() ||
-                    SyntaxFacts.GetTypeDeclarationKind(kind) != SyntaxKind.None)
-                {
-                    return null;
-                }
+            var corresponding = branchOperation.GetCorrespondingOperation();
+            if (corresponding is null)
+                return null;
 
-                node = node.Parent;
-            }
-
-            return node;
-        }
-
-        static SyntaxNode? TryFindBreakableConstruct(SyntaxNode? node)
-        {
-            while (node is not null && !node.IsBreakableConstruct())
-            {
-                if (node.IsReturnableConstruct() ||
-                    SyntaxFacts.GetTypeDeclarationKind(node.Kind()) != SyntaxKind.None)
-                {
-                    return null;
-                }
-
-                node = node.Parent;
-            }
-
-            return node;
+            return isBreak
+                ? corresponding.Syntax.GetLastToken().Span.End
+                : corresponding.Syntax.GetFirstToken().Span.Start;
         }
 
         static SyntaxNode? TryFindContainingReturnableConstruct(SyntaxNode? node)

--- a/src/LanguageServer/ProtocolUnitTests/Definitions/GoToDefinitionTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Definitions/GoToDefinitionTests.cs
@@ -374,6 +374,155 @@ public sealed class GoToDefinitionTests : AbstractLanguageServerProtocolTests
         Assert.True(service.DidMapSpans);
     }
 
+    [Theory, CombinatorialData]
+    public async Task TestGotoDefinitionAsync_LabeledBreak_OnKeyword(bool mutatingLspWorkspace)
+    {
+        var markup = """
+            class C
+            {
+                void F()
+                {
+                    outer: while (true)
+                    {
+                        {|caret:|}break outer;
+                    {|definition:}|}
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+        var results = await RunGotoDefinitionAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+        AssertLocationsEqual(testLspServer.GetLocations("definition"), results);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestGotoDefinitionAsync_LabeledContinue_OnKeyword(bool mutatingLspWorkspace)
+    {
+        var markup = """
+            class C
+            {
+                void F()
+                {
+                    outer: {|definition:while|} (true)
+                    {
+                        {|caret:|}continue outer;
+                    }
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+        var results = await RunGotoDefinitionAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+        AssertLocationsEqual(testLspServer.GetLocations("definition"), results);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestGotoDefinitionAsync_LabeledBreak_OnKeyword_OuterLoop(bool mutatingLspWorkspace)
+    {
+        var markup = """
+            class C
+            {
+                void F()
+                {
+                    outer: while (true)
+                    {
+                        while (true)
+                        {
+                            {|caret:|}break outer;
+                        }
+                    {|definition:}|}
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+        var results = await RunGotoDefinitionAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+        AssertLocationsEqual(testLspServer.GetLocations("definition"), results);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestGotoDefinitionAsync_LabeledBreak_OnIdentifier(bool mutatingLspWorkspace)
+    {
+        var markup = """
+            class C
+            {
+                void F()
+                {
+                    {|definition:outer|}: while (true)
+                    {
+                        break {|caret:|}outer;
+                    }
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+        var results = await RunGotoDefinitionAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+        AssertLocationsEqual(testLspServer.GetLocations("definition"), results);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestGotoDefinitionAsync_LabeledContinue_OnIdentifier(bool mutatingLspWorkspace)
+    {
+        var markup = """
+            class C
+            {
+                void F()
+                {
+                    {|definition:outer|}: while (true)
+                    {
+                        continue {|caret:|}outer;
+                    }
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+        var results = await RunGotoDefinitionAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+        AssertLocationsEqual(testLspServer.GetLocations("definition"), results);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestGotoDefinitionAsync_LabeledBreak_OuterLoop(bool mutatingLspWorkspace)
+    {
+        var markup = """
+            class C
+            {
+                void F()
+                {
+                    {|definition:outer|}: while (true)
+                    {
+                        while (true)
+                        {
+                            break {|caret:|}outer;
+                        }
+                    }
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+        var results = await RunGotoDefinitionAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+        AssertLocationsEqual(testLspServer.GetLocations("definition"), results);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestGotoDefinitionAsync_LabeledContinue_OuterLoop(bool mutatingLspWorkspace)
+    {
+        var markup = """
+            class C
+            {
+                void F()
+                {
+                    {|definition:outer|}: for (int i = 0; i < 10; i++)
+                    {
+                        while (true)
+                        {
+                            continue {|caret:|}outer;
+                        }
+                    }
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace);
+        var results = await RunGotoDefinitionAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+        AssertLocationsEqual(testLspServer.GetLocations("definition"), results);
+    }
+
     private static async Task<LSP.Location[]> RunGotoDefinitionAsync(TestLspServer testLspServer, LSP.Location caret)
     {
         return await testLspServer.ExecuteRequestAsync<LSP.TextDocumentPositionParams, LSP.Location[]>(LSP.Methods.TextDocumentDefinitionName,


### PR DESCRIPTION
Tests-only PR. Go To Definition on the label identifier in `break outer;` / `continue outer;` already works through the existing symbol pipeline (GetSymbolInfo → ILabelSymbol → declaration location).

Tests cover immediate and outer loop targets for both break and continue.