### PR TITLE
Add keyword highlighting for labeled break/continue

### DIFF
--- a/src/EditorFeatures/CSharpTest/KeywordHighlighting/LoopHighlighterTests.cs
+++ b/src/EditorFeatures/CSharpTest/KeywordHighlighting/LoopHighlighterTests.cs
@@ -1186,4 +1186,161 @@ public sealed class LoopHighlighterTests : AbstractCSharpKeywordHighlighterTests
                 }
             }
             """);
+
+    [Fact]
+    public Task TestLabeledBreak_CursorOnWhile()
+        => TestAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    outer: {|Cursor:[|while|]|} (true)
+                    {
+                        while (true)
+                        {
+                            [|break|] outer;
+                        }
+                    }
+                }
+            }
+            """);
+
+    [Fact]
+    public Task TestLabeledBreak_CursorOnBreak()
+        => TestAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    outer: [|while|] (true)
+                    {
+                        while (true)
+                        {
+                            {|Cursor:[|break|]|} outer;
+                        }
+                    }
+                }
+            }
+            """);
+
+    [Fact]
+    public Task TestLabeledContinue_CursorOnFor()
+        => TestAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    outer: {|Cursor:[|for|]|} (int i = 0; i < 10; i++)
+                    {
+                        while (true)
+                        {
+                            [|continue|] outer;
+                        }
+                    }
+                }
+            }
+            """);
+
+    [Fact]
+    public Task TestLabeledContinue_CursorOnContinue()
+        => TestAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    outer: [|for|] (int i = 0; i < 10; i++)
+                    {
+                        while (true)
+                        {
+                            {|Cursor:[|continue|]|} outer;
+                        }
+                    }
+                }
+            }
+            """);
+
+    [Fact]
+    public Task TestLabeledAndUnlabeled_CursorOnOuterWhile()
+        => TestAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    outer: {|Cursor:[|while|]|} (true)
+                    {
+                        while (true)
+                        {
+                            [|break|] outer;
+                            break;
+                        }
+                        [|break|];
+                        [|continue|];
+                    }
+                }
+            }
+            """);
+
+    [Fact]
+    public Task TestLabeledBreak_DoesNotHighlightMismatchedLabel()
+        => TestAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        inner: {|Cursor:[|while|]|} (true)
+                        {
+                            [|break|] inner;
+                        }
+                    }
+                }
+            }
+            """);
+
+    [Fact]
+    public Task TestUnlabeledLoop_DoesNotHighlightLabeledBreak()
+        => TestAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        {|Cursor:[|while|]|} (true)
+                        {
+                            break outer;
+                            [|break|];
+                        }
+                    }
+                }
+            }
+            """);
+
+    [Fact]
+    public Task TestUnlabeledLoop_DoesNotHighlightLabeledContinue()
+        => TestAsync(
+            """
+            class C
+            {
+                void M()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        {|Cursor:[|while|]|} (true)
+                        {
+                            continue outer;
+                            [|continue|];
+                        }
+                    }
+                }
+            }
+            """);
 }

--- a/src/EditorFeatures/CSharpTest/KeywordHighlighting/SwitchStatementHighlighterTests.cs
+++ b/src/EditorFeatures/CSharpTest/KeywordHighlighting/SwitchStatementHighlighterTests.cs
@@ -818,4 +818,71 @@ public sealed class SwitchStatementHighlighterTests : AbstractCSharpKeywordHighl
                 }
             }
             """);
+
+    [Fact]
+    public Task TestLabeledBreak_CursorOnSwitch()
+        => TestAsync(
+            """
+            class C
+            {
+                void M(int x)
+                {
+                    outer: {|Cursor:[|switch|]|} (x)
+                    {
+                        [|case|] 0[|:|]
+                            switch (x)
+                            {
+                                case 1:
+                                    [|break|] outer;
+                            }
+                            [|break|];
+                    }
+                }
+            }
+            """);
+
+    [Fact]
+    public Task TestLabeledBreak_CursorOnBreak()
+        => TestAsync(
+            """
+            class C
+            {
+                void M(int x)
+                {
+                    outer: [|switch|] (x)
+                    {
+                        [|case|] 0[|:|]
+                            switch (x)
+                            {
+                                case 1:
+                                    {|Cursor:[|break|]|} outer;
+                            }
+                            [|break|];
+                    }
+                }
+            }
+            """);
+
+    [Fact]
+    public Task TestUnlabeledSwitch_DoesNotHighlightLabeledBreak()
+        => TestAsync(
+            """
+            class C
+            {
+                void M(int x)
+                {
+                    outer: switch (x)
+                    {
+                        case 0:
+                            {|Cursor:[|switch|]|} (x)
+                            {
+                                [|case|] 1[|:|]
+                                    break outer;
+                                    [|break|];
+                            }
+                            break;
+                    }
+                }
+            }
+            """);
 }

--- a/src/Features/CSharp/Portable/Highlighting/KeywordHighlighters/LoopHighlighter.cs
+++ b/src/Features/CSharp/Portable/Highlighting/KeywordHighlighters/LoopHighlighter.cs
@@ -38,6 +38,8 @@ internal sealed class LoopHighlighter() : AbstractKeywordHighlighter(findInsideT
     protected override void AddHighlightsForNode(
         SyntaxNode node, List<TextSpan> spans, CancellationToken cancellationToken)
     {
+        var labelName = (node.Parent as LabeledStatementSyntax)?.Identifier.ValueText;
+
         switch (node)
         {
             case DoStatementSyntax doStatement:
@@ -54,7 +56,7 @@ internal sealed class LoopHighlighter() : AbstractKeywordHighlighter(findInsideT
                 break;
         }
 
-        HighlightRelatedKeywords(node, spans, highlightBreaks: true, highlightContinues: true);
+        HighlightRelatedKeywords(node, spans, highlightBreaks: true, highlightContinues: true, labelName);
     }
 
     private static void HighlightDoStatement(DoStatementSyntax statement, List<TextSpan> spans)
@@ -77,32 +79,56 @@ internal sealed class LoopHighlighter() : AbstractKeywordHighlighter(findInsideT
     /// Finds all breaks and continues that are a child of this node, and adds the appropriate spans to the spans list.
     /// </summary>
     private static void HighlightRelatedKeywords(SyntaxNode node, List<TextSpan> spans,
-        bool highlightBreaks, bool highlightContinues)
+        bool highlightBreaks, bool highlightContinues, string? labelName)
     {
-        Debug.Assert(highlightBreaks || highlightContinues);
+        Debug.Assert(highlightBreaks || highlightContinues || labelName != null);
 
-        if (highlightBreaks && node is BreakStatementSyntax breakStatement)
+        if (node is BreakStatementSyntax breakStatement)
         {
-            spans.Add(breakStatement.BreakKeyword.Span);
-            spans.Add(EmptySpan(breakStatement.SemicolonToken.Span.End));
-        }
-        else if (highlightContinues && node is ContinueStatementSyntax continueStatement)
-        {
-            spans.Add(continueStatement.ContinueKeyword.Span);
-            spans.Add(EmptySpan(continueStatement.SemicolonToken.Span.End));
-        }
-        else
-        {
-            foreach (var child in node.ChildNodes())
+            if (breakStatement.Name is { } breakName)
             {
-                var highlightBreaksForChild = highlightBreaks && !child.IsBreakableConstruct();
-                var highlightContinuesForChild = highlightContinues && !child.IsContinuableConstruct();
-
-                // Only recurse if we have anything to do
-                if (highlightBreaksForChild || highlightContinuesForChild)
+                if (breakName.Identifier.ValueText == labelName)
                 {
-                    HighlightRelatedKeywords(child, spans, highlightBreaksForChild, highlightContinuesForChild);
+                    spans.Add(breakStatement.BreakKeyword.Span);
+                    spans.Add(EmptySpan(breakStatement.SemicolonToken.Span.End));
                 }
+            }
+            else if (highlightBreaks)
+            {
+                spans.Add(breakStatement.BreakKeyword.Span);
+                spans.Add(EmptySpan(breakStatement.SemicolonToken.Span.End));
+            }
+
+            return;
+        }
+
+        if (node is ContinueStatementSyntax continueStatement)
+        {
+            if (continueStatement.Name is { } continueName)
+            {
+                if (continueName.Identifier.ValueText == labelName)
+                {
+                    spans.Add(continueStatement.ContinueKeyword.Span);
+                    spans.Add(EmptySpan(continueStatement.SemicolonToken.Span.End));
+                }
+            }
+            else if (highlightContinues)
+            {
+                spans.Add(continueStatement.ContinueKeyword.Span);
+                spans.Add(EmptySpan(continueStatement.SemicolonToken.Span.End));
+            }
+
+            return;
+        }
+
+        foreach (var child in node.ChildNodes())
+        {
+            var highlightBreaksForChild = highlightBreaks && !child.IsBreakableConstruct();
+            var highlightContinuesForChild = highlightContinues && !child.IsContinuableConstruct();
+
+            if (highlightBreaksForChild || highlightContinuesForChild || labelName != null)
+            {
+                HighlightRelatedKeywords(child, spans, highlightBreaksForChild, highlightContinuesForChild, labelName);
             }
         }
     }

--- a/src/Features/CSharp/Portable/Highlighting/KeywordHighlighters/SwitchStatementHighlighter.cs
+++ b/src/Features/CSharp/Portable/Highlighting/KeywordHighlighters/SwitchStatementHighlighter.cs
@@ -36,6 +36,8 @@ internal sealed class SwitchStatementHighlighter() : AbstractKeywordHighlighter<
     protected override void AddHighlights(
         SwitchStatementSyntax switchStatement, List<TextSpan> spans, CancellationToken cancellationToken)
     {
+        var labelName = (switchStatement.Parent as LabeledStatementSyntax)?.Identifier.ValueText;
+
         spans.Add(switchStatement.SwitchKeyword.Span);
 
         foreach (var switchSection in switchStatement.Sections)
@@ -46,7 +48,7 @@ internal sealed class SwitchStatementHighlighter() : AbstractKeywordHighlighter<
                 spans.Add(EmptySpan(label.ColonToken.Span.End));
             }
 
-            HighlightRelatedKeywords(switchSection, spans, highlightBreaks: true, highlightGotos: true);
+            HighlightRelatedKeywords(switchSection, spans, highlightBreaks: true, highlightGotos: true, labelName);
         }
     }
 
@@ -55,47 +57,63 @@ internal sealed class SwitchStatementHighlighter() : AbstractKeywordHighlighter<
     /// list.
     /// </summary>
     private static void HighlightRelatedKeywords(SyntaxNode node, List<TextSpan> spans,
-        bool highlightBreaks, bool highlightGotos)
+        bool highlightBreaks, bool highlightGotos, string? labelName)
     {
-        Debug.Assert(highlightBreaks || highlightGotos);
+        Debug.Assert(highlightBreaks || highlightGotos || labelName != null);
 
-        if (highlightBreaks && node is BreakStatementSyntax breakStatement)
+        if (node is BreakStatementSyntax breakStatement)
         {
-            spans.Add(breakStatement.BreakKeyword.Span);
-            spans.Add(EmptySpan(breakStatement.SemicolonToken.Span.End));
-        }
-        else if (highlightGotos && node is GotoStatementSyntax gotoStatement)
-        {
-            // We only want to highlight 'goto case' and 'goto default', not plain old goto statements,
-            // but if the label is missing, we do highlight 'goto' assuming it's more likely that
-            // the user is in the middle of typing 'goto case' or 'goto default'.
-            if (gotoStatement.Kind() is SyntaxKind.GotoCaseStatement or SyntaxKind.GotoDefaultStatement ||
-                gotoStatement is { Expression.IsMissing: true })
+            if (breakStatement.Name is { } breakName)
             {
-                var start = gotoStatement.GotoKeyword.SpanStart;
-                var end = !gotoStatement.CaseOrDefaultKeyword.IsKind(SyntaxKind.None)
-                    ? gotoStatement.CaseOrDefaultKeyword.Span.End
-                    : gotoStatement.GotoKeyword.Span.End;
-
-                spans.Add(TextSpan.FromBounds(start, end));
-                spans.Add(EmptySpan(gotoStatement.SemicolonToken.Span.End));
-            }
-        }
-        else
-        {
-            foreach (var childNodeOrToken in node.ChildNodesAndTokens())
-            {
-                if (!childNodeOrToken.AsNode(out var child))
-                    continue;
-
-                var highlightBreaksForChild = highlightBreaks && !child.IsBreakableConstruct();
-                var highlightGotosForChild = highlightGotos && !child.IsKind(SyntaxKind.SwitchStatement);
-
-                // Only recurse if we have anything to do
-                if (highlightBreaksForChild || highlightGotosForChild)
+                if (breakName.Identifier.ValueText == labelName)
                 {
-                    HighlightRelatedKeywords(child, spans, highlightBreaksForChild, highlightGotosForChild);
+                    spans.Add(breakStatement.BreakKeyword.Span);
+                    spans.Add(EmptySpan(breakStatement.SemicolonToken.Span.End));
                 }
+            }
+            else if (highlightBreaks)
+            {
+                spans.Add(breakStatement.BreakKeyword.Span);
+                spans.Add(EmptySpan(breakStatement.SemicolonToken.Span.End));
+            }
+
+            return;
+        }
+
+        if (node is GotoStatementSyntax gotoStatement)
+        {
+            if (highlightGotos)
+            {
+                // We only want to highlight 'goto case' and 'goto default', not plain old goto statements,
+                // but if the label is missing, we do highlight 'goto' assuming it's more likely that
+                // the user is in the middle of typing 'goto case' or 'goto default'.
+                if (gotoStatement.Kind() is SyntaxKind.GotoCaseStatement or SyntaxKind.GotoDefaultStatement ||
+                    gotoStatement is { Expression.IsMissing: true })
+                {
+                    var start = gotoStatement.GotoKeyword.SpanStart;
+                    var end = !gotoStatement.CaseOrDefaultKeyword.IsKind(SyntaxKind.None)
+                        ? gotoStatement.CaseOrDefaultKeyword.Span.End
+                        : gotoStatement.GotoKeyword.Span.End;
+
+                    spans.Add(TextSpan.FromBounds(start, end));
+                    spans.Add(EmptySpan(gotoStatement.SemicolonToken.Span.End));
+                }
+            }
+
+            return;
+        }
+
+        foreach (var childNodeOrToken in node.ChildNodesAndTokens())
+        {
+            if (!childNodeOrToken.AsNode(out var child))
+                continue;
+
+            var highlightBreaksForChild = highlightBreaks && !child.IsBreakableConstruct();
+            var highlightGotosForChild = highlightGotos && !child.IsKind(SyntaxKind.SwitchStatement);
+
+            if (highlightBreaksForChild || highlightGotosForChild || labelName != null)
+            {
+                HighlightRelatedKeywords(child, spans, highlightBreaksForChild, highlightGotosForChild, labelName);
             }
         }
     }


### PR DESCRIPTION
Extends loop and switch keyword highlighters to support labeled break/continue.

- `break outer;` nested inside inner loops highlights the outer `while`/`for`/etc. keyword
- Unlabeled `break`/`continue` behavior is unchanged
- Labeled statements matching by name are found even past inner loop/switch boundaries
- `labelName` parameter threaded through `HighlightRelatedKeywords` recursion