### PR TITLE
Add Find References tests for labeled break/continue

### DIFF
--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.LabelSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.LabelSymbols.vb
@@ -107,5 +107,134 @@ End Module
 </Workspace>
             Await TestAPIAndFeature(input, kind, host)
         End Function
+
+        <WpfTheory, CombinatorialData>
+        Public Async Function TestLabeledBreak_FromDeclaration(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+        class C
+        {
+            void M()
+            {
+            $${|Definition:outer|}:
+                while (true)
+                {
+                    while (true)
+                    {
+                        break [|outer|];
+                    }
+                }
+            }
+        }
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData>
+        Public Async Function TestLabeledBreak_FromReference(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+        class C
+        {
+            void M()
+            {
+            {|Definition:outer|}:
+                while (true)
+                {
+                    while (true)
+                    {
+                        break [|$$outer|];
+                    }
+                }
+            }
+        }
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData>
+        Public Async Function TestLabeledContinue_FromDeclaration(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+        class C
+        {
+            void M()
+            {
+            $${|Definition:outer|}:
+                for (int i = 0; i &lt; 10; i++)
+                {
+                    while (true)
+                    {
+                        continue [|outer|];
+                    }
+                }
+            }
+        }
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData>
+        Public Async Function TestLabeledBreakAndContinue_MultipleReferences(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+        class C
+        {
+            void M()
+            {
+            $${|Definition:outer|}:
+                while (true)
+                {
+                    while (true)
+                    {
+                        break [|outer|];
+                        continue [|outer|];
+                    }
+                }
+            }
+        }
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
+
+        <WpfTheory, CombinatorialData>
+        Public Async Function TestLabeledBreakAndGoto_MixedReferences(kind As TestKind, host As TestHost) As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+        class C
+        {
+            void M()
+            {
+            $${|Definition:outer|}:
+                while (true)
+                {
+                    goto [|outer|];
+                    break [|outer|];
+                }
+            }
+        }
+        </Document>
+    </Project>
+</Workspace>
+            Await TestAPIAndFeature(input, kind, host)
+        End Function
     End Class
 End Namespace

--- a/src/LanguageServer/ProtocolUnitTests/Highlights/DocumentHighlightTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Highlights/DocumentHighlightTests.cs
@@ -148,6 +148,101 @@ public sealed class DocumentHighlightTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(expectedLocations[0].Range, results[0].Range);
     }
 
+    [Theory, CombinatorialData]
+    public async Task TestGetDocumentHighlightAsync_LabeledBreak(bool lspMutatingWorkspace)
+    {
+        var markup =
+            """
+            class C
+            {
+                void M()
+                {
+                    {|text:outer|}: while (true)
+                    {
+                        while (true)
+                        {
+                            break {|caret:|}{|text:outer|};
+                        }
+                    }
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, lspMutatingWorkspace);
+
+        var expectedLocations = testLspServer.GetLocations("text");
+
+        var results = await RunGetDocumentHighlightAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+
+        Assert.Equal(2, results.Length);
+        Assert.All(results, r => Assert.Equal(LSP.DocumentHighlightKind.Text, r.Kind));
+        Assert.Equal(expectedLocations[0].Range, results[0].Range);
+        Assert.Equal(expectedLocations[1].Range, results[1].Range);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestGetDocumentHighlightAsync_LabeledContinue(bool lspMutatingWorkspace)
+    {
+        var markup =
+            """
+            class C
+            {
+                void M()
+                {
+                    {|caret:|}{|text:outer|}: for (int i = 0; i < 10; i++)
+                    {
+                        while (true)
+                        {
+                            continue {|text:outer|};
+                        }
+                    }
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, lspMutatingWorkspace);
+
+        var expectedLocations = testLspServer.GetLocations("text");
+
+        var results = await RunGetDocumentHighlightAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+
+        Assert.Equal(2, results.Length);
+        Assert.All(results, r => Assert.Equal(LSP.DocumentHighlightKind.Text, r.Kind));
+        Assert.Equal(expectedLocations[0].Range, results[0].Range);
+        Assert.Equal(expectedLocations[1].Range, results[1].Range);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestGetDocumentHighlightAsync_LabeledBreakAndContinue_MultipleReferences(bool lspMutatingWorkspace)
+    {
+        var markup =
+            """
+            class C
+            {
+                void M()
+                {
+                    {|caret:|}{|text:outer|}: while (true)
+                    {
+                        while (true)
+                        {
+                            break {|text:outer|};
+                            continue {|text:outer|};
+                        }
+                    }
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, lspMutatingWorkspace);
+
+        var expectedLocations = testLspServer.GetLocations("text");
+
+        var results = await RunGetDocumentHighlightAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+
+        Assert.Equal(3, results.Length);
+        Assert.All(results, r => Assert.Equal(LSP.DocumentHighlightKind.Text, r.Kind));
+        Assert.Equal(expectedLocations[0].Range, results[0].Range);
+        Assert.Equal(expectedLocations[1].Range, results[1].Range);
+        Assert.Equal(expectedLocations[2].Range, results[2].Range);
+    }
+
     private static async Task<LSP.DocumentHighlight[]> RunGetDocumentHighlightAsync(TestLspServer testLspServer, LSP.Location caret)
     {
         var results = await testLspServer.ExecuteRequestAsync<LSP.TextDocumentPositionParams, LSP.DocumentHighlight[]>(LSP.Methods.TextDocumentDocumentHighlightName,


### PR DESCRIPTION
Tests-only PR. Find References on labels in `break outer;` / `continue outer;` already works through the existing `LabelSymbolReferenceFinder` + `GetSymbolInfo` pipeline.

5 tests: FAR from declaration, from reference, continue labels, multiple references (break + continue), and mixed goto + break references.