### PR TITLE
Add Quick Info (hover) tests for labeled break/continue

### DIFF
--- a/src/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
@@ -619,7 +619,7 @@ class C
         await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, CapabilitiesWithVSExtensions);
         var results = await RunGetHoverAsync(testLspServer, testLspServer.GetLocations("caret").Single());
         Assert.NotNull(results);
-        VerifyVSContent(results, "label outer");
+        VerifyVSContent(results, $"({FeaturesResources.label}) outer");
     }
 
     [Theory, CombinatorialData]
@@ -644,7 +644,7 @@ class C
         await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, CapabilitiesWithVSExtensions);
         var results = await RunGetHoverAsync(testLspServer, testLspServer.GetLocations("caret").Single());
         Assert.NotNull(results);
-        VerifyVSContent(results, "label outer");
+        VerifyVSContent(results, $"({FeaturesResources.label}) outer");
     }
 
     private static async Task<LSP.Hover> RunGetHoverAsync(

--- a/src/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
@@ -600,6 +600,53 @@ class C
             """, results.Contents.Fourth.Value);
     }
 
+    [Theory, CombinatorialData]
+    public async Task TestGetHoverAsync_LabeledBreak(bool mutatingLspWorkspace)
+    {
+        var markup =
+            """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        break {|caret:outer|};
+                    }
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, CapabilitiesWithVSExtensions);
+        var results = await RunGetHoverAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+        Assert.NotNull(results);
+        VerifyVSContent(results, "label outer");
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestGetHoverAsync_LabeledContinue(bool mutatingLspWorkspace)
+    {
+        var markup =
+            """
+            class C
+            {
+                void M()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        while (true)
+                        {
+                            continue {|caret:outer|};
+                        }
+                    }
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, CapabilitiesWithVSExtensions);
+        var results = await RunGetHoverAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+        Assert.NotNull(results);
+        VerifyVSContent(results, "label outer");
+    }
+
     private static async Task<LSP.Hover> RunGetHoverAsync(
         TestLspServer testLspServer,
         LSP.Location caret,


### PR DESCRIPTION
## Summary
- Add hover tests verifying that Quick Info on the label identifier in break outer and continue outer shows the expected label outer tooltip.
- No production code changes needed - this works via the existing GetSymbolInfo to ILabelSymbol pipeline.

## Test plan
- TestGetHoverAsync_LabeledBreak
- TestGetHoverAsync_LabeledContinue
- Build succeeds