### PR TITLE
Add grabbag validation tests for labeled break/continue

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
@@ -2286,6 +2286,60 @@ public sealed partial class SyntacticClassifierTests : AbstractCSharpClassifierT
             Punctuation.Colon);
 
     [Theory, CombinatorialData]
+    public Task TestLabeledBreak(TestHost testHost)
+        => TestInMethodAsync(
+            """
+            outer: while (true)
+            {
+                break outer;
+            }
+            """,
+            testHost,
+            Label("outer"),
+            Punctuation.Colon,
+            ControlKeyword("while"),
+            Punctuation.OpenParen,
+            Keyword("true"),
+            Punctuation.CloseParen,
+            Punctuation.OpenCurly,
+            ControlKeyword("break"),
+            Label("outer"),
+            Punctuation.Semicolon,
+            Punctuation.CloseCurly);
+
+    [Theory, CombinatorialData]
+    public Task TestLabeledContinue(TestHost testHost)
+        => TestInMethodAsync(
+            """
+            loop: for (int i = 0; i < 10; i++)
+            {
+                continue loop;
+            }
+            """,
+            testHost,
+            Label("loop"),
+            Punctuation.Colon,
+            ControlKeyword("for"),
+            Punctuation.OpenParen,
+            Keyword("int"),
+            Local("i"),
+            Operators.Equals,
+            Number("0"),
+            Punctuation.Semicolon,
+            Local("i"),
+            Operators.LessThan,
+            Number("10"),
+            Punctuation.Semicolon,
+            Local("i"),
+            Operators.PlusPlus,
+            Punctuation.CloseParen,
+            Punctuation.OpenCurly,
+            ControlKeyword("continue"),
+            Label("loop"),
+            Punctuation.Semicolon,
+            Punctuation.CloseCurly);
+
+    [Theory, CombinatorialData]
     public Task Attribute(TestHost testHost)
         => TestAsync(
 @"[assembly: Goo]",

--- a/src/Features/CSharpTest/EditAndContinue/BreakpointSpansTests.cs
+++ b/src/Features/CSharpTest/EditAndContinue/BreakpointSpansTests.cs
@@ -5473,4 +5473,36 @@ public sealed class BreakpointSpansTests
             """);
 
     #endregion
+
+    [Fact]
+    public void LabeledBreak()
+        => TestSpan(
+            """
+            class C
+            {
+                void Goo()
+                {
+                    outer: while (true)
+                    {
+            $$            [|break outer;|]
+                    }
+                }
+            }
+            """);
+
+    [Fact]
+    public void LabeledContinue()
+        => TestSpan(
+            """
+            class C
+            {
+                void Goo()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+            $$            [|continue outer;|]
+                    }
+                }
+            }
+            """);
 }

--- a/src/Features/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
+++ b/src/Features/CSharpTest/EditAndContinue/TopLevelEditingTests.cs
@@ -12255,6 +12255,76 @@ public sealed class TopLevelEditingTests : EditingTestBase
     }
 
     [Fact]
+    public void MethodUpdate_LabeledBreakStatement()
+    {
+        var src1 = """
+
+            class C
+            {
+                static void F()
+                {
+                    outer: while (true)
+                    {
+                        break outer;
+                    }
+                }
+            }
+            """;
+        var src2 = """
+
+            class C
+            {
+                static void F()
+                {
+                    outer: while (true)
+                    {
+                        if (true) break outer;
+                    }
+                }
+            }
+            """;
+
+        var edits = GetTopEdits(src1, src2);
+
+        edits.VerifySemanticDiagnostics();
+    }
+
+    [Fact]
+    public void MethodUpdate_LabeledContinueStatement()
+    {
+        var src1 = """
+
+            class C
+            {
+                static void F()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        continue outer;
+                    }
+                }
+            }
+            """;
+        var src2 = """
+
+            class C
+            {
+                static void F()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        if (i > 5) continue outer;
+                    }
+                }
+            }
+            """;
+
+        var edits = GetTopEdits(src1, src2);
+
+        edits.VerifySemanticDiagnostics();
+    }
+
+    [Fact]
     public void MethodUpdate_LocalFunctionsParameterRefnessInBody()
     {
         var src1 = @"class C { public void M(int a) { void f(ref int b) => b = 1; } }";

--- a/src/Features/CSharpTest/ExtractMethod/ExtractMethodCodeRefactoringTests.cs
+++ b/src/Features/CSharpTest/ExtractMethod/ExtractMethodCodeRefactoringTests.cs
@@ -8783,4 +8783,59 @@ class Program
                 }
             }
             """);
+
+    [Fact]
+    public Task TestFlowControl_LabeledBreakAndContinue()
+        => TestInRegularAndScriptAsync(
+            """
+            class C
+            {
+                private int Repro(int[] x)
+                {
+                    outer: foreach (var v in x)
+                    {
+                        [|if (v == 0)
+                        {
+                            break outer;
+                        }
+                        
+                        continue outer;|]
+                    }
+
+                    return 0;
+                }
+            }
+            """,
+            """
+            class C
+            {
+                private int Repro(int[] x)
+                {
+                    outer: foreach (var v in x)
+                    {
+                        bool flowControl = {|Rename:NewMethod|}(v);
+                        if (flowControl)
+                        {
+                            continue;
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+            
+                    return 0;
+                }
+
+                private static bool NewMethod(int v)
+                {
+                    if (v == 0)
+                    {
+                        return false;
+                    }
+
+                    return true;
+                }
+            }
+            """);
 }

--- a/src/LanguageServer/ProtocolUnitTests/Rename/RenameTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Rename/RenameTests.cs
@@ -452,6 +452,79 @@ public sealed class RenameTests(ITestOutputHelper testOutputHelper) : AbstractLa
         Assert.True(service.DidMapEdits);
     }
 
+    [Theory, CombinatorialData]
+    public async Task TestRenameAsync_LabeledBreak(bool mutatingLspWorkspace)
+    {
+        await using var testLspServer = await CreateTestLspServerAsync("""
+            class C
+            {
+                void M()
+                {
+                    {|caret:|}{|renamed:outer|}: while (true)
+                    {
+                        break {|renamed:outer|};
+                    }
+                }
+            }
+            """, mutatingLspWorkspace);
+        var renameLocation = testLspServer.GetLocations("caret").First();
+        var renameValue = "loop";
+        var expectedEdits = testLspServer.GetLocations("renamed").Select(location => new LSP.TextEdit() { NewText = renameValue, Range = location.Range });
+
+        var results = await RunRenameAsync(testLspServer, CreateRenameParams(renameLocation, renameValue));
+        AssertJsonEquals(expectedEdits, ((TextDocumentEdit[])results.DocumentChanges).First().Edits);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestRenameAsync_LabeledContinue(bool mutatingLspWorkspace)
+    {
+        await using var testLspServer = await CreateTestLspServerAsync("""
+            class C
+            {
+                void M()
+                {
+                    {|caret:|}{|renamed:outer|}: for (int i = 0; i < 10; i++)
+                    {
+                        while (true)
+                        {
+                            continue {|renamed:outer|};
+                        }
+                    }
+                }
+            }
+            """, mutatingLspWorkspace);
+        var renameLocation = testLspServer.GetLocations("caret").First();
+        var renameValue = "loop";
+        var expectedEdits = testLspServer.GetLocations("renamed").Select(location => new LSP.TextEdit() { NewText = renameValue, Range = location.Range });
+
+        var results = await RunRenameAsync(testLspServer, CreateRenameParams(renameLocation, renameValue));
+        AssertJsonEquals(expectedEdits, ((TextDocumentEdit[])results.DocumentChanges).First().Edits);
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestRenameAsync_LabeledBreakAndContinue_FromReference(bool mutatingLspWorkspace)
+    {
+        await using var testLspServer = await CreateTestLspServerAsync("""
+            class C
+            {
+                void M()
+                {
+                    {|renamed:outer|}: while (true)
+                    {
+                        break {|caret:|}{|renamed:outer|};
+                        continue {|renamed:outer|};
+                    }
+                }
+            }
+            """, mutatingLspWorkspace);
+        var renameLocation = testLspServer.GetLocations("caret").First();
+        var renameValue = "loop";
+        var expectedEdits = testLspServer.GetLocations("renamed").Select(location => new LSP.TextEdit() { NewText = renameValue, Range = location.Range });
+
+        var results = await RunRenameAsync(testLspServer, CreateRenameParams(renameLocation, renameValue));
+        AssertJsonEquals(expectedEdits, ((TextDocumentEdit[])results.DocumentChanges).First().Edits);
+    }
+
     private static LSP.RenameParams CreateRenameParams(LSP.Location location, string newName)
         => new()
         {


### PR DESCRIPTION
## Summary
- **Classification**: label identifier in `break outer;` / `continue loop;` is classified as `LabelName`
- **Extract Method**: flow control with labeled break/continue targeting immediate loop produces correct bool dispatch
- **Edit and Continue**: editing method bodies containing labeled break/continue produces no rude edits
- **Breakpoint spans**: labeled break/continue statements get correct breakpoint spans
- **Rename**: renaming a label from declaration or reference updates all `break`/`continue` reference sites

## Test plan
- [x] `TestLabeledBreak` / `TestLabeledContinue` — syntactic classification
- [x] `TestFlowControl_LabeledBreakAndContinue` — extract method
- [x] `MethodUpdate_LabeledBreakStatement` / `MethodUpdate_LabeledContinueStatement` — ENC
- [x] `LabeledBreak` / `LabeledContinue` — breakpoint spans
- [x] `TestRenameAsync_LabeledBreak` / `TestRenameAsync_LabeledContinue` / `TestRenameAsync_LabeledBreakAndContinue_FromReference` — rename
- [x] All three projects build successfully