### PR TITLE
2/8: Add binding, lowering, emit, and semantic model for labeled break/continue

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -403,6 +403,26 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
+        /// Returns the <see cref="GeneratedLabelSymbol"/> for a break statement targeting the given label,
+        /// or the nearest enclosing loop/switch if <paramref name="labelName"/> is null.
+        /// </summary>
+        internal virtual GeneratedLabelSymbol? GetBreakLabel(string? labelName)
+        {
+            RoslynDebug.Assert(Next is object);
+            return Next.GetBreakLabel(labelName);
+        }
+
+        /// <summary>
+        /// Returns the <see cref="GeneratedLabelSymbol"/> for a continue statement targeting the given label,
+        /// or the nearest enclosing loop if <paramref name="labelName"/> is null.
+        /// </summary>
+        internal virtual GeneratedLabelSymbol? GetContinueLabel(string? labelName)
+        {
+            RoslynDebug.Assert(Next is object);
+            return Next.GetContinueLabel(labelName);
+        }
+
+        /// <summary>
         /// Get the element type of this iterator.
         /// </summary>
         /// <returns>Element type of the current iterator, or an error type.</returns>

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2947,16 +2947,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundStatement BindBreak(BreakStatementSyntax node, BindingDiagnosticBag diagnostics)
         {
-            if (node.Name != null)
-            {
-                MessageID.IDS_FeatureLabeledBreakContinue.CheckFeatureAvailability(diagnostics, node, node.Name.GetLocation());
-                return BindLabeledBreakOrContinue(node, node.Name, isBreak: true, diagnostics);
-            }
+            var labelName = node.Name?.Identifier.ValueText;
+            if (labelName != null)
+                MessageID.IDS_FeatureLabeledBreakContinue.CheckFeatureAvailability(diagnostics, node, node.Name!.GetLocation());
 
-            var target = this.BreakLabel;
-            if ((object)target == null)
+            var target = this.GetBreakLabel(labelName);
+            if (target == null)
             {
-                Error(diagnostics, ErrorCode.ERR_NoBreakOrCont, node);
+                Error(diagnostics, labelName != null ? ErrorCode.ERR_NoBreakOrContId : ErrorCode.ERR_NoBreakOrCont, node.Name ?? (SyntaxNode)node, labelName ?? "");
                 return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
             }
             return new BoundBreakStatement(node, target);
@@ -2964,88 +2962,17 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundStatement BindContinue(ContinueStatementSyntax node, BindingDiagnosticBag diagnostics)
         {
-            if (node.Name != null)
-            {
-                MessageID.IDS_FeatureLabeledBreakContinue.CheckFeatureAvailability(diagnostics, node, node.Name.GetLocation());
-                return BindLabeledBreakOrContinue(node, node.Name, isBreak: false, diagnostics);
-            }
+            var labelName = node.Name?.Identifier.ValueText;
+            if (labelName != null)
+                MessageID.IDS_FeatureLabeledBreakContinue.CheckFeatureAvailability(diagnostics, node, node.Name!.GetLocation());
 
-            var target = this.ContinueLabel;
-            if ((object)target == null)
+            var target = this.GetContinueLabel(labelName);
+            if (target == null)
             {
-                Error(diagnostics, ErrorCode.ERR_NoBreakOrCont, node);
+                Error(diagnostics, labelName != null ? ErrorCode.ERR_NoBreakOrContId : ErrorCode.ERR_NoBreakOrCont, node.Name ?? (SyntaxNode)node, labelName ?? "");
                 return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
             }
             return new BoundContinueStatement(node, target);
-        }
-
-        private BoundStatement BindLabeledBreakOrContinue(StatementSyntax node, IdentifierNameSyntax labelName, bool isBreak, BindingDiagnosticBag diagnostics)
-        {
-            var result = LookupResult.GetInstance();
-            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
-            this.LookupSymbolsWithFallback(result, labelName.Identifier.ValueText, arity: 0, useSiteInfo: ref useSiteInfo, options: LookupOptions.LabelsOnly);
-            diagnostics.Add(node, useSiteInfo);
-
-            if (!result.IsMultiViable)
-            {
-                result.Free();
-                Error(diagnostics, ErrorCode.ERR_LabelNotFound, labelName, labelName.Identifier.ValueText);
-                return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
-            }
-
-            var labelSymbol = (SourceLabelSymbol)result.Symbols.First();
-            result.Free();
-
-            // Walk from the label's identifier token to the LabeledStatementSyntax, then unwrap nested
-            // labels to find the actual target statement.
-            var identifierParent = labelSymbol.IdentifierNodeOrToken.Parent;
-            if (identifierParent is not LabeledStatementSyntax labeledStatement)
-            {
-                Error(diagnostics, isBreak ? ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch : ErrorCode.ERR_LabeledContinueNotOnLoop, labelName, labelName.Identifier.ValueText);
-                return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
-            }
-
-            var targetStatement = labeledStatement.Statement;
-            while (targetStatement is LabeledStatementSyntax nested)
-                targetStatement = nested.Statement;
-
-            // Verify the target statement is a loop (for continue) or loop/switch (for break).
-            bool isLoop = targetStatement is WhileStatementSyntax or DoStatementSyntax or ForStatementSyntax or ForEachStatementSyntax or ForEachVariableStatementSyntax;
-            bool isSwitch = targetStatement is SwitchStatementSyntax;
-
-            if (isBreak ? !(isLoop || isSwitch) : !isLoop)
-            {
-                Error(diagnostics, isBreak ? ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch : ErrorCode.ERR_LabeledContinueNotOnLoop, labelName, labelName.Identifier.ValueText);
-                return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
-            }
-
-            // Verify the labeled statement lexically contains this break/continue.
-            if (!targetStatement.Span.Contains(node.Span))
-            {
-                Error(diagnostics, ErrorCode.ERR_LabeledBreakContinueNotContaining, labelName, labelName.Identifier.ValueText);
-                return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
-            }
-
-            // Walk the binder chain to find the LoopBinder or SwitchBinder for the target syntax.
-            for (var binder = this; binder != null; binder = binder.Next)
-            {
-                if (binder is LoopBinder loopBinder && loopBinder.ScopeDesignator == targetStatement)
-                {
-                    var label = isBreak ? loopBinder.BreakLabel : loopBinder.ContinueLabel;
-                    return isBreak
-                        ? new BoundBreakStatement(node, label)
-                        : (BoundStatement)new BoundContinueStatement(node, label);
-                }
-
-                if (isBreak && binder is SwitchBinder switchBinder && switchBinder.ScopeDesignator == targetStatement)
-                {
-                    return new BoundBreakStatement(node, switchBinder.BreakLabel);
-                }
-            }
-
-            // Should not normally reach here if the containment check passed, but report an error defensively.
-            Error(diagnostics, ErrorCode.ERR_LabeledBreakContinueNotContaining, labelName, labelName.Identifier.ValueText);
-            return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
         }
 
         private static SwitchBinder GetSwitchBinder(Binder binder)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2957,7 +2957,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Error(diagnostics, labelName != null ? ErrorCode.ERR_NoBreakOrContId : ErrorCode.ERR_NoBreakOrCont, node.Name ?? (SyntaxNode)node, labelName ?? "");
                 return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
             }
-            return new BoundBreakStatement(node, target);
+            return new BoundBreakStatement(node, target, GetSourceLabel(node.Name));
         }
 
         private BoundStatement BindContinue(ContinueStatementSyntax node, BindingDiagnosticBag diagnostics)
@@ -2972,7 +2972,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Error(diagnostics, labelName != null ? ErrorCode.ERR_NoBreakOrContId : ErrorCode.ERR_NoBreakOrCont, node.Name ?? (SyntaxNode)node, labelName ?? "");
                 return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
             }
-            return new BoundContinueStatement(node, target);
+            return new BoundContinueStatement(node, target, GetSourceLabel(node.Name));
+        }
+
+        private LabelSymbol GetSourceLabel(IdentifierNameSyntax name)
+        {
+            if (name == null)
+                return null;
+
+            return (this.BindLabel(name, BindingDiagnosticBag.Discarded) as BoundLabel)?.Label;
         }
 
         private static SwitchBinder GetSwitchBinder(Binder binder)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2957,7 +2957,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Error(diagnostics, labelName != null ? ErrorCode.ERR_NoBreakOrContId : ErrorCode.ERR_NoBreakOrCont, node.Name ?? (SyntaxNode)node, labelName ?? "");
                 return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
             }
-            return new BoundBreakStatement(node, target, GetSourceLabel(node.Name));
+            return new BoundBreakStatement(node, target, BindLabelExpression(node.Name, diagnostics));
         }
 
         private BoundStatement BindContinue(ContinueStatementSyntax node, BindingDiagnosticBag diagnostics)
@@ -2972,15 +2972,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Error(diagnostics, labelName != null ? ErrorCode.ERR_NoBreakOrContId : ErrorCode.ERR_NoBreakOrCont, node.Name ?? (SyntaxNode)node, labelName ?? "");
                 return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
             }
-            return new BoundContinueStatement(node, target, GetSourceLabel(node.Name));
+            return new BoundContinueStatement(node, target, BindLabelExpression(node.Name, diagnostics));
         }
 
-        private LabelSymbol GetSourceLabel(IdentifierNameSyntax name)
+        private BoundLabel BindLabelExpression(IdentifierNameSyntax name, BindingDiagnosticBag diagnostics)
         {
             if (name == null)
                 return null;
 
-            return (this.BindLabel(name, BindingDiagnosticBag.Discarded) as BoundLabel)?.Label;
+            return this.BindLabel(name, diagnostics) as BoundLabel;
         }
 
         private static SwitchBinder GetSwitchBinder(Binder binder)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2947,6 +2947,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundStatement BindBreak(BreakStatementSyntax node, BindingDiagnosticBag diagnostics)
         {
+            if (node.Name != null)
+            {
+                MessageID.IDS_FeatureLabeledBreakContinue.CheckFeatureAvailability(diagnostics, node, node.Name.GetLocation());
+                return BindLabeledBreakOrContinue(node, node.Name, isBreak: true, diagnostics);
+            }
+
             var target = this.BreakLabel;
             if ((object)target == null)
             {
@@ -2958,6 +2964,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundStatement BindContinue(ContinueStatementSyntax node, BindingDiagnosticBag diagnostics)
         {
+            if (node.Name != null)
+            {
+                MessageID.IDS_FeatureLabeledBreakContinue.CheckFeatureAvailability(diagnostics, node, node.Name.GetLocation());
+                return BindLabeledBreakOrContinue(node, node.Name, isBreak: false, diagnostics);
+            }
+
             var target = this.ContinueLabel;
             if ((object)target == null)
             {
@@ -2965,6 +2977,75 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
             }
             return new BoundContinueStatement(node, target);
+        }
+
+        private BoundStatement BindLabeledBreakOrContinue(StatementSyntax node, IdentifierNameSyntax labelName, bool isBreak, BindingDiagnosticBag diagnostics)
+        {
+            var result = LookupResult.GetInstance();
+            CompoundUseSiteInfo<AssemblySymbol> useSiteInfo = GetNewCompoundUseSiteInfo(diagnostics);
+            this.LookupSymbolsWithFallback(result, labelName.Identifier.ValueText, arity: 0, useSiteInfo: ref useSiteInfo, options: LookupOptions.LabelsOnly);
+            diagnostics.Add(node, useSiteInfo);
+
+            if (!result.IsMultiViable)
+            {
+                result.Free();
+                Error(diagnostics, ErrorCode.ERR_LabelNotFound, labelName, labelName.Identifier.ValueText);
+                return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
+            }
+
+            var labelSymbol = (SourceLabelSymbol)result.Symbols.First();
+            result.Free();
+
+            // Walk from the label's identifier token to the LabeledStatementSyntax, then unwrap nested
+            // labels to find the actual target statement.
+            var identifierParent = labelSymbol.IdentifierNodeOrToken.Parent;
+            if (identifierParent is not LabeledStatementSyntax labeledStatement)
+            {
+                Error(diagnostics, isBreak ? ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch : ErrorCode.ERR_LabeledContinueNotOnLoop, labelName, labelName.Identifier.ValueText);
+                return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
+            }
+
+            var targetStatement = labeledStatement.Statement;
+            while (targetStatement is LabeledStatementSyntax nested)
+                targetStatement = nested.Statement;
+
+            // Verify the target statement is a loop (for continue) or loop/switch (for break).
+            bool isLoop = targetStatement is WhileStatementSyntax or DoStatementSyntax or ForStatementSyntax or ForEachStatementSyntax or ForEachVariableStatementSyntax;
+            bool isSwitch = targetStatement is SwitchStatementSyntax;
+
+            if (isBreak ? !(isLoop || isSwitch) : !isLoop)
+            {
+                Error(diagnostics, isBreak ? ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch : ErrorCode.ERR_LabeledContinueNotOnLoop, labelName, labelName.Identifier.ValueText);
+                return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
+            }
+
+            // Verify the labeled statement lexically contains this break/continue.
+            if (!targetStatement.Span.Contains(node.Span))
+            {
+                Error(diagnostics, ErrorCode.ERR_LabeledBreakContinueNotContaining, labelName, labelName.Identifier.ValueText);
+                return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
+            }
+
+            // Walk the binder chain to find the LoopBinder or SwitchBinder for the target syntax.
+            for (var binder = this; binder != null; binder = binder.Next)
+            {
+                if (binder is LoopBinder loopBinder && loopBinder.ScopeDesignator == targetStatement)
+                {
+                    var label = isBreak ? loopBinder.BreakLabel : loopBinder.ContinueLabel;
+                    return isBreak
+                        ? new BoundBreakStatement(node, label)
+                        : (BoundStatement)new BoundContinueStatement(node, label);
+                }
+
+                if (isBreak && binder is SwitchBinder switchBinder && switchBinder.ScopeDesignator == targetStatement)
+                {
+                    return new BoundBreakStatement(node, switchBinder.BreakLabel);
+                }
+            }
+
+            // Should not normally reach here if the containment check passed, but report an error defensively.
+            Error(diagnostics, ErrorCode.ERR_LabeledBreakContinueNotContaining, labelName, labelName.Identifier.ValueText);
+            return new BoundBadStatement(node, ImmutableArray<BoundNode>.Empty, hasErrors: true);
         }
 
         private static SwitchBinder GetSwitchBinder(Binder binder)

--- a/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
@@ -139,6 +139,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        internal override GeneratedLabelSymbol? GetBreakLabel(string? labelName) => null;
+
+        internal override GeneratedLabelSymbol? GetContinueLabel(string? labelName) => null;
+
         internal override BoundExpression? ConditionalReceiverExpression
         {
             get

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             => _syntax.AwaitKeyword != default;
 
         public ForEachLoopBinder(Binder enclosing, CommonForEachStatementSyntax syntax)
-            : base(enclosing)
+            : base(enclosing, syntax)
         {
             Debug.Assert(syntax != null);
             _syntax = syntax;

--- a/src/Compilers/CSharp/Portable/Binder/ForLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForLoopBinder.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly ForStatementSyntax _syntax;
 
         public ForLoopBinder(Binder enclosing, ForStatementSyntax syntax)
-            : base(enclosing)
+            : base(enclosing, syntax)
         {
             Debug.Assert(syntax != null);
             _syntax = syntax;

--- a/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
@@ -119,6 +119,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        internal override GeneratedLabelSymbol GetBreakLabel(string labelName) => null;
+
+        internal override GeneratedLabelSymbol GetContinueLabel(string labelName) => null;
+
         protected override void ValidateYield(YieldStatementSyntax node, BindingDiagnosticBag diagnostics)
         {
         }

--- a/src/Compilers/CSharp/Portable/Binder/LoopBinderContext.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LoopBinderContext.cs
@@ -14,12 +14,14 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         private readonly GeneratedLabelSymbol _breakLabel;
         private readonly GeneratedLabelSymbol _continueLabel;
+        private readonly string _labelName;
 
-        protected LoopBinder(Binder enclosing)
+        protected LoopBinder(Binder enclosing, SyntaxNode loopSyntax)
             : base(enclosing)
         {
             _breakLabel = new GeneratedLabelSymbol("break");
             _continueLabel = new GeneratedLabelSymbol("continue");
+            _labelName = loopSyntax.Parent is LabeledStatementSyntax labeled ? labeled.Identifier.ValueText : null;
         }
 
         internal override GeneratedLabelSymbol BreakLabel
@@ -37,5 +39,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return _continueLabel;
             }
         }
+
+        internal override GeneratedLabelSymbol GetBreakLabel(string labelName)
+            => (labelName is null || labelName == _labelName) ? _breakLabel : Next.GetBreakLabel(labelName);
+
+        internal override GeneratedLabelSymbol GetContinueLabel(string labelName)
+            => (labelName is null || labelName == _labelName) ? _continueLabel : Next.GetContinueLabel(labelName);
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
@@ -25,11 +25,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         private ImmutableArray<Diagnostic> _switchGoverningDiagnostics;
         private ImmutableArray<AssemblySymbol> _switchGoverningDependencies;
 
+        private readonly string _labelName;
+
         private SwitchBinder(Binder next, SwitchStatementSyntax switchSyntax)
             : base(next)
         {
             SwitchSyntax = switchSyntax;
             _breakLabel = new GeneratedLabelSymbol("break");
+            _labelName = switchSyntax.Parent is LabeledStatementSyntax labeled ? labeled.Identifier.ValueText : null;
         }
 
         protected bool PatternsEnabled =>
@@ -170,6 +173,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return _breakLabel;
             }
         }
+
+        internal override GeneratedLabelSymbol GetBreakLabel(string labelName)
+            => (labelName is null || labelName == _labelName) ? _breakLabel : Next.GetBreakLabel(labelName);
 
         protected override ImmutableArray<LabelSymbol> BuildLabels()
         {

--- a/src/Compilers/CSharp/Portable/Binder/WhileBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WhileBinder.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly StatementSyntax _syntax;
 
         public WhileBinder(Binder enclosing, StatementSyntax syntax)
-            : base(enclosing)
+            : base(enclosing, syntax)
         {
             Debug.Assert(syntax != null && (syntax.IsKind(SyntaxKind.WhileStatement) || syntax.IsKind(SyntaxKind.DoStatement)));
             _syntax = syntax;

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1175,11 +1175,25 @@
   </Node>
 
   <Node Name="BoundBreakStatement" Base="BoundStatement">
+    <!-- The compiler-generated label that the break jumps to (e.g. the loop's "break" label). -->
     <Field Name="Label" Type="LabelSymbol" />
+    <!--
+    For a labeled break (e.g. "break outer;" targeting "outer: while (true) { ... }"), this is the
+    user-declared label symbol for "outer:".  Null for an ordinary unlabeled "break;".  Used by
+    ControlFlowPass to mark the label as referenced, suppressing the WRN_UnreferencedLabel warning.
+    -->
+    <Field Name="SourceLabelOpt" Type="LabelSymbol?" />
   </Node>
 
   <Node Name="BoundContinueStatement" Base="BoundStatement">
+    <!-- The compiler-generated label that the continue jumps to (e.g. the loop's "continue" label). -->
     <Field Name="Label" Type="LabelSymbol" />
+    <!--
+    For a labeled continue (e.g. "continue outer;" targeting "outer: for (...) { ... }"), this is the
+    user-declared label symbol for "outer:".  Null for an ordinary unlabeled "continue;".  Used by
+    ControlFlowPass to mark the label as referenced, suppressing the WRN_UnreferencedLabel warning.
+    -->
+    <Field Name="SourceLabelOpt" Type="LabelSymbol?" />
   </Node>
 
   <Node Name="BoundSwitchStatement" Base="BoundStatement">

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1179,10 +1179,11 @@
     <Field Name="Label" Type="LabelSymbol" />
     <!--
     For a labeled break (e.g. "break outer;" targeting "outer: while (true) { ... }"), this is the
-    user-declared label symbol for "outer:".  Null for an ordinary unlabeled "break;".  Used by
-    ControlFlowPass to mark the label as referenced, suppressing the WRN_UnreferencedLabel warning.
+    bound label expression for "outer".  Null for an ordinary unlabeled "break;".  Used by the
+    SemanticModel to resolve GetSymbolInfo on the label, and by ControlFlowPass (via SourceLabelOpt
+    below) to suppress WRN_UnreferencedLabel.
     -->
-    <Field Name="SourceLabelOpt" Type="LabelSymbol?" />
+    <Field Name="LabelExpressionOpt" Type="BoundLabel?" />
   </Node>
 
   <Node Name="BoundContinueStatement" Base="BoundStatement">
@@ -1190,10 +1191,11 @@
     <Field Name="Label" Type="LabelSymbol" />
     <!--
     For a labeled continue (e.g. "continue outer;" targeting "outer: for (...) { ... }"), this is the
-    user-declared label symbol for "outer:".  Null for an ordinary unlabeled "continue;".  Used by
-    ControlFlowPass to mark the label as referenced, suppressing the WRN_UnreferencedLabel warning.
+    bound label expression for "outer".  Null for an ordinary unlabeled "continue;".  Used by the
+    SemanticModel to resolve GetSymbolInfo on the label, and by ControlFlowPass (via LabelExpressionOpt's
+    Label) to suppress WRN_UnreferencedLabel.
     -->
-    <Field Name="SourceLabelOpt" Type="LabelSymbol?" />
+    <Field Name="LabelExpressionOpt" Type="BoundLabel?" />
   </Node>
 
   <Node Name="BoundSwitchStatement" Base="BoundStatement">

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -8090,6 +8090,18 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureUserDefinedCompoundAssignmentOperators" xml:space="preserve">
     <value>user-defined compound assignment operators</value>
   </data>
+  <data name="IDS_FeatureLabeledBreakContinue" xml:space="preserve">
+    <value>labeled break and continue</value>
+  </data>
+  <data name="ERR_LabeledBreakContinueNotOnLoopOrSwitch" xml:space="preserve">
+    <value>The label '{0}' does not refer to a containing loop or switch statement</value>
+  </data>
+  <data name="ERR_LabeledContinueNotOnLoop" xml:space="preserve">
+    <value>The label '{0}' does not refer to a containing loop statement</value>
+  </data>
+  <data name="ERR_LabeledBreakContinueNotContaining" xml:space="preserve">
+    <value>The label '{0}' does not refer to a statement that contains this break or continue statement</value>
+  </data>
   <data name="ERR_OperatorsMustBePublic" xml:space="preserve">
     <value>User-defined operator '{0}' must be declared public</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -759,6 +759,9 @@
   <data name="ERR_NoBreakOrCont" xml:space="preserve">
     <value>No enclosing loop out of which to break or continue</value>
   </data>
+  <data name="ERR_NoBreakOrContId" xml:space="preserve">
+    <value>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</value>
+  </data>
   <data name="ERR_DuplicateLabel" xml:space="preserve">
     <value>The label '{0}' is a duplicate</value>
   </data>
@@ -8092,15 +8095,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="IDS_FeatureLabeledBreakContinue" xml:space="preserve">
     <value>labeled break and continue</value>
-  </data>
-  <data name="ERR_LabeledBreakContinueNotOnLoopOrSwitch" xml:space="preserve">
-    <value>The label '{0}' does not refer to a containing loop or switch statement</value>
-  </data>
-  <data name="ERR_LabeledContinueNotOnLoop" xml:space="preserve">
-    <value>The label '{0}' does not refer to a containing loop statement</value>
-  </data>
-  <data name="ERR_LabeledBreakContinueNotContaining" xml:space="preserve">
-    <value>The label '{0}' does not refer to a statement that contains this break or continue statement</value>
   </data>
   <data name="ERR_OperatorsMustBePublic" xml:space="preserve">
     <value>User-defined operator '{0}' must be declared public</value>

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -2195,6 +2195,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             case BaseExpressionColonSyntax:
                             case NameEqualsSyntax:
                             case GotoStatementSyntax { RawKind: (int)SyntaxKind.GotoStatement }:
+                            case BreakStatementSyntax { Name: not null }:
+                            case ContinueStatementSyntax { Name: not null }:
                             case TypeParameterConstraintClauseSyntax:
                             case AliasQualifiedNameSyntax:
                                 // These nodes do not have anything interesting for us

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2489,6 +2489,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_LabeledBreakContinueNotOnLoopOrSwitch = 9379,
         ERR_LabeledContinueNotOnLoop = 9380,
         ERR_LabeledBreakContinueNotContaining = 9381,
+        ERR_NoBreakOrContId = 9382,
 
         // Note: you will need to do the following after adding errors:
         //  1) Update ErrorFacts.IsBuildOnlyDiagnostic (src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs)

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -2486,6 +2486,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         ERR_PPShebangNotOnFirstLine = 9378,
 
+        ERR_LabeledBreakContinueNotOnLoopOrSwitch = 9379,
+        ERR_LabeledContinueNotOnLoop = 9380,
+        ERR_LabeledBreakContinueNotContaining = 9381,
+
         // Note: you will need to do the following after adding errors:
         //  1) Update ErrorFacts.IsBuildOnlyDiagnostic (src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs)
         //  2) Add message to CSharpResources.resx

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -2590,9 +2590,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 or ErrorCode.ERR_UnionConstructorCallsDefaultConstructor
                 or ErrorCode.ERR_UnsafeConstructorConstraint
                 or ErrorCode.WRN_UnsafeMeaningless
-                or ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch
-                or ErrorCode.ERR_LabeledContinueNotOnLoop
-                or ErrorCode.ERR_LabeledBreakContinueNotContaining
+                or ErrorCode.ERR_NoBreakOrContId
                     => false,
             };
 #pragma warning restore CS8524 // The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value.

--- a/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorFacts.cs
@@ -2590,6 +2590,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 or ErrorCode.ERR_UnionConstructorCallsDefaultConstructor
                 or ErrorCode.ERR_UnsafeConstructorConstraint
                 or ErrorCode.WRN_UnsafeMeaningless
+                or ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch
+                or ErrorCode.ERR_LabeledContinueNotOnLoop
+                or ErrorCode.ERR_LabeledBreakContinueNotContaining
                     => false,
             };
 #pragma warning restore CS8524 // The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value.

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -310,6 +310,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         IDS_FeatureUnsafeEvolution = MessageBase + 12859,
 
         IDS_FeatureUnions = MessageBase + 12860,
+
+        IDS_FeatureLabeledBreakContinue = MessageBase + 12861,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -505,6 +507,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_FeatureNullConditionalAssignment:
                 case MessageID.IDS_FeatureExpressionOptionalAndNamedArguments:
                 case MessageID.IDS_FeatureUserDefinedCompoundAssignmentOperators:
+                case MessageID.IDS_FeatureLabeledBreakContinue:
                     return LanguageVersion.CSharp14;
 
                 // C# 13.0 features.

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -495,6 +495,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_FeatureCollectionExpressionArguments:
                 case MessageID.IDS_FeatureUnsafeEvolution: // https://github.com/dotnet/roslyn/issues/82546: keep this in preview until C# 16
                 case MessageID.IDS_FeatureUnions:
+                case MessageID.IDS_FeatureLabeledBreakContinue:
                     return LanguageVersion.Preview;
 
                 // C# 14.0 features.
@@ -507,7 +508,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_FeatureNullConditionalAssignment:
                 case MessageID.IDS_FeatureExpressionOptionalAndNamedArguments:
                 case MessageID.IDS_FeatureUserDefinedCompoundAssignmentOperators:
-                case MessageID.IDS_FeatureLabeledBreakContinue:
                     return LanguageVersion.CSharp14;
 
                 // C# 13.0 features.

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
@@ -371,16 +371,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitBreakStatement(BoundBreakStatement node)
         {
-            if (node.SourceLabelOpt != null)
-                _labelsUsed.Add(node.SourceLabelOpt);
+            if (node.LabelExpressionOpt != null)
+                _labelsUsed.Add(node.LabelExpressionOpt.Label);
 
             return base.VisitBreakStatement(node);
         }
 
         public override BoundNode VisitContinueStatement(BoundContinueStatement node)
         {
-            if (node.SourceLabelOpt != null)
-                _labelsUsed.Add(node.SourceLabelOpt);
+            if (node.LabelExpressionOpt != null)
+                _labelsUsed.Add(node.LabelExpressionOpt.Label);
 
             return base.VisitContinueStatement(node);
         }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
@@ -369,6 +369,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             return base.VisitGotoStatement(node);
         }
 
+        public override BoundNode VisitBreakStatement(BoundBreakStatement node)
+        {
+            if (node.SourceLabelOpt != null)
+                _labelsUsed.Add(node.SourceLabelOpt);
+
+            return base.VisitBreakStatement(node);
+        }
+
+        public override BoundNode VisitContinueStatement(BoundContinueStatement node)
+        {
+            if (node.SourceLabelOpt != null)
+                _labelsUsed.Add(node.SourceLabelOpt);
+
+            return base.VisitContinueStatement(node);
+        }
+
         protected override void VisitSwitchSection(BoundSwitchSection node, bool isLastSection)
         {
             base.VisitSwitchSection(node, isLastSection);

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -3753,34 +3753,37 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundBreakStatement : BoundStatement
     {
-        public BoundBreakStatement(SyntaxNode syntax, LabelSymbol label, bool hasErrors)
+        public BoundBreakStatement(SyntaxNode syntax, LabelSymbol label, LabelSymbol? sourceLabelOpt, bool hasErrors)
             : base(BoundKind.BreakStatement, syntax, hasErrors)
         {
 
             RoslynDebug.Assert(label is object, "Field 'label' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
             this.Label = label;
+            this.SourceLabelOpt = sourceLabelOpt;
         }
 
-        public BoundBreakStatement(SyntaxNode syntax, LabelSymbol label)
+        public BoundBreakStatement(SyntaxNode syntax, LabelSymbol label, LabelSymbol? sourceLabelOpt)
             : base(BoundKind.BreakStatement, syntax)
         {
 
             RoslynDebug.Assert(label is object, "Field 'label' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
             this.Label = label;
+            this.SourceLabelOpt = sourceLabelOpt;
         }
 
         public LabelSymbol Label { get; }
+        public LabelSymbol? SourceLabelOpt { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitBreakStatement(this);
 
-        public BoundBreakStatement Update(LabelSymbol label)
+        public BoundBreakStatement Update(LabelSymbol label, LabelSymbol? sourceLabelOpt)
         {
-            if (!Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(label, this.Label))
+            if (!Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(label, this.Label) || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(sourceLabelOpt, this.SourceLabelOpt))
             {
-                var result = new BoundBreakStatement(this.Syntax, label, this.HasErrors);
+                var result = new BoundBreakStatement(this.Syntax, label, sourceLabelOpt, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -3790,34 +3793,37 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundContinueStatement : BoundStatement
     {
-        public BoundContinueStatement(SyntaxNode syntax, LabelSymbol label, bool hasErrors)
+        public BoundContinueStatement(SyntaxNode syntax, LabelSymbol label, LabelSymbol? sourceLabelOpt, bool hasErrors)
             : base(BoundKind.ContinueStatement, syntax, hasErrors)
         {
 
             RoslynDebug.Assert(label is object, "Field 'label' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
             this.Label = label;
+            this.SourceLabelOpt = sourceLabelOpt;
         }
 
-        public BoundContinueStatement(SyntaxNode syntax, LabelSymbol label)
+        public BoundContinueStatement(SyntaxNode syntax, LabelSymbol label, LabelSymbol? sourceLabelOpt)
             : base(BoundKind.ContinueStatement, syntax)
         {
 
             RoslynDebug.Assert(label is object, "Field 'label' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
             this.Label = label;
+            this.SourceLabelOpt = sourceLabelOpt;
         }
 
         public LabelSymbol Label { get; }
+        public LabelSymbol? SourceLabelOpt { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitContinueStatement(this);
 
-        public BoundContinueStatement Update(LabelSymbol label)
+        public BoundContinueStatement Update(LabelSymbol label, LabelSymbol? sourceLabelOpt)
         {
-            if (!Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(label, this.Label))
+            if (!Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(label, this.Label) || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(sourceLabelOpt, this.SourceLabelOpt))
             {
-                var result = new BoundContinueStatement(this.Syntax, label, this.HasErrors);
+                var result = new BoundContinueStatement(this.Syntax, label, sourceLabelOpt, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -11711,12 +11717,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitBreakStatement(BoundBreakStatement node)
         {
             LabelSymbol label = this.VisitLabelSymbol(node.Label);
-            return node.Update(label);
+            LabelSymbol? sourceLabelOpt = this.VisitLabelSymbol(node.SourceLabelOpt);
+            return node.Update(label, sourceLabelOpt);
         }
         public override BoundNode? VisitContinueStatement(BoundContinueStatement node)
         {
             LabelSymbol label = this.VisitLabelSymbol(node.Label);
-            return node.Update(label);
+            LabelSymbol? sourceLabelOpt = this.VisitLabelSymbol(node.SourceLabelOpt);
+            return node.Update(label, sourceLabelOpt);
         }
         public override BoundNode? VisitSwitchStatement(BoundSwitchStatement node)
         {
@@ -16321,12 +16329,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override TreeDumperNode VisitBreakStatement(BoundBreakStatement node, object? arg) => new TreeDumperNode("breakStatement", null, new TreeDumperNode[]
         {
             new TreeDumperNode("label", node.Label, null),
+            new TreeDumperNode("sourceLabelOpt", node.SourceLabelOpt, null),
             new TreeDumperNode("hasErrors", node.HasErrors, null)
         }
         );
         public override TreeDumperNode VisitContinueStatement(BoundContinueStatement node, object? arg) => new TreeDumperNode("continueStatement", null, new TreeDumperNode[]
         {
             new TreeDumperNode("label", node.Label, null),
+            new TreeDumperNode("sourceLabelOpt", node.SourceLabelOpt, null),
             new TreeDumperNode("hasErrors", node.HasErrors, null)
         }
         );

--- a/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/BoundNodes.xml.Generated.cs
@@ -3753,37 +3753,27 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundBreakStatement : BoundStatement
     {
-        public BoundBreakStatement(SyntaxNode syntax, LabelSymbol label, LabelSymbol? sourceLabelOpt, bool hasErrors)
-            : base(BoundKind.BreakStatement, syntax, hasErrors)
+        public BoundBreakStatement(SyntaxNode syntax, LabelSymbol label, BoundLabel? labelExpressionOpt, bool hasErrors = false)
+            : base(BoundKind.BreakStatement, syntax, hasErrors || labelExpressionOpt.HasErrors())
         {
 
             RoslynDebug.Assert(label is object, "Field 'label' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
             this.Label = label;
-            this.SourceLabelOpt = sourceLabelOpt;
-        }
-
-        public BoundBreakStatement(SyntaxNode syntax, LabelSymbol label, LabelSymbol? sourceLabelOpt)
-            : base(BoundKind.BreakStatement, syntax)
-        {
-
-            RoslynDebug.Assert(label is object, "Field 'label' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
-
-            this.Label = label;
-            this.SourceLabelOpt = sourceLabelOpt;
+            this.LabelExpressionOpt = labelExpressionOpt;
         }
 
         public LabelSymbol Label { get; }
-        public LabelSymbol? SourceLabelOpt { get; }
+        public BoundLabel? LabelExpressionOpt { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitBreakStatement(this);
 
-        public BoundBreakStatement Update(LabelSymbol label, LabelSymbol? sourceLabelOpt)
+        public BoundBreakStatement Update(LabelSymbol label, BoundLabel? labelExpressionOpt)
         {
-            if (!Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(label, this.Label) || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(sourceLabelOpt, this.SourceLabelOpt))
+            if (!Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(label, this.Label) || labelExpressionOpt != this.LabelExpressionOpt)
             {
-                var result = new BoundBreakStatement(this.Syntax, label, sourceLabelOpt, this.HasErrors);
+                var result = new BoundBreakStatement(this.Syntax, label, labelExpressionOpt, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -3793,37 +3783,27 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal sealed partial class BoundContinueStatement : BoundStatement
     {
-        public BoundContinueStatement(SyntaxNode syntax, LabelSymbol label, LabelSymbol? sourceLabelOpt, bool hasErrors)
-            : base(BoundKind.ContinueStatement, syntax, hasErrors)
+        public BoundContinueStatement(SyntaxNode syntax, LabelSymbol label, BoundLabel? labelExpressionOpt, bool hasErrors = false)
+            : base(BoundKind.ContinueStatement, syntax, hasErrors || labelExpressionOpt.HasErrors())
         {
 
             RoslynDebug.Assert(label is object, "Field 'label' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
 
             this.Label = label;
-            this.SourceLabelOpt = sourceLabelOpt;
-        }
-
-        public BoundContinueStatement(SyntaxNode syntax, LabelSymbol label, LabelSymbol? sourceLabelOpt)
-            : base(BoundKind.ContinueStatement, syntax)
-        {
-
-            RoslynDebug.Assert(label is object, "Field 'label' cannot be null (make the type nullable in BoundNodes.xml to remove this check)");
-
-            this.Label = label;
-            this.SourceLabelOpt = sourceLabelOpt;
+            this.LabelExpressionOpt = labelExpressionOpt;
         }
 
         public LabelSymbol Label { get; }
-        public LabelSymbol? SourceLabelOpt { get; }
+        public BoundLabel? LabelExpressionOpt { get; }
 
         [DebuggerStepThrough]
         public override BoundNode? Accept(BoundTreeVisitor visitor) => visitor.VisitContinueStatement(this);
 
-        public BoundContinueStatement Update(LabelSymbol label, LabelSymbol? sourceLabelOpt)
+        public BoundContinueStatement Update(LabelSymbol label, BoundLabel? labelExpressionOpt)
         {
-            if (!Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(label, this.Label) || !Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(sourceLabelOpt, this.SourceLabelOpt))
+            if (!Symbols.SymbolEqualityComparer.ConsiderEverything.Equals(label, this.Label) || labelExpressionOpt != this.LabelExpressionOpt)
             {
-                var result = new BoundContinueStatement(this.Syntax, label, sourceLabelOpt, this.HasErrors);
+                var result = new BoundContinueStatement(this.Syntax, label, labelExpressionOpt, this.HasErrors);
                 result.CopyAttributes(this);
                 return result;
             }
@@ -10426,8 +10406,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.Visit(node.Expression);
             return null;
         }
-        public override BoundNode? VisitBreakStatement(BoundBreakStatement node) => null;
-        public override BoundNode? VisitContinueStatement(BoundContinueStatement node) => null;
+        public override BoundNode? VisitBreakStatement(BoundBreakStatement node)
+        {
+            this.Visit(node.LabelExpressionOpt);
+            return null;
+        }
+        public override BoundNode? VisitContinueStatement(BoundContinueStatement node)
+        {
+            this.Visit(node.LabelExpressionOpt);
+            return null;
+        }
         public override BoundNode? VisitSwitchStatement(BoundSwitchStatement node)
         {
             this.Visit(node.Expression);
@@ -11717,14 +11705,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode? VisitBreakStatement(BoundBreakStatement node)
         {
             LabelSymbol label = this.VisitLabelSymbol(node.Label);
-            LabelSymbol? sourceLabelOpt = this.VisitLabelSymbol(node.SourceLabelOpt);
-            return node.Update(label, sourceLabelOpt);
+            BoundLabel? labelExpressionOpt = (BoundLabel?)this.Visit(node.LabelExpressionOpt);
+            return node.Update(label, labelExpressionOpt);
         }
         public override BoundNode? VisitContinueStatement(BoundContinueStatement node)
         {
             LabelSymbol label = this.VisitLabelSymbol(node.Label);
-            LabelSymbol? sourceLabelOpt = this.VisitLabelSymbol(node.SourceLabelOpt);
-            return node.Update(label, sourceLabelOpt);
+            BoundLabel? labelExpressionOpt = (BoundLabel?)this.Visit(node.LabelExpressionOpt);
+            return node.Update(label, labelExpressionOpt);
         }
         public override BoundNode? VisitSwitchStatement(BoundSwitchStatement node)
         {
@@ -16329,14 +16317,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override TreeDumperNode VisitBreakStatement(BoundBreakStatement node, object? arg) => new TreeDumperNode("breakStatement", null, new TreeDumperNode[]
         {
             new TreeDumperNode("label", node.Label, null),
-            new TreeDumperNode("sourceLabelOpt", node.SourceLabelOpt, null),
+            new TreeDumperNode("labelExpressionOpt", null, new TreeDumperNode[] { Visit(node.LabelExpressionOpt, null) }),
             new TreeDumperNode("hasErrors", node.HasErrors, null)
         }
         );
         public override TreeDumperNode VisitContinueStatement(BoundContinueStatement node, object? arg) => new TreeDumperNode("continueStatement", null, new TreeDumperNode[]
         {
             new TreeDumperNode("label", node.Label, null),
-            new TreeDumperNode("sourceLabelOpt", node.SourceLabelOpt, null),
+            new TreeDumperNode("labelExpressionOpt", null, new TreeDumperNode[] { Visit(node.LabelExpressionOpt, null) }),
             new TreeDumperNode("hasErrors", node.HasErrors, null)
         }
         );

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">Argument diagnosticId atributu Experimental musí být platný identifikátor</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">{0} neobsahuje definici pro {1} a nebyla nalezena žádná přístupná metoda rozšíření {1}, která by přijímala první argument typu {0}. (Nechtěli jste místo toho iterovat asynchronní kolekci pomocí await foreach?)</target>
@@ -6683,6 +6668,11 @@
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">Příkazy break a continue nejsou uvedené ve smyčce.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">Argument diagnosticId atributu Experimental musí být platný identifikátor</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">{0} neobsahuje definici pro {1} a nebyla nalezena žádná přístupná metoda rozšíření {1}, která by přijímala první argument typu {0}. (Nechtěli jste místo toho iterovat asynchronní kolekci pomocí await foreach?)</target>
@@ -3000,6 +3015,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">člen instance v nameof</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">Das diagnosticId-Argument für das Experimental-Attribut muss ein gültiger Bezeichner sein.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">„{0}“ enthält keine Definition für „{1}“, und es konnte keine zugängliche Erweiterungsmethode „{1}“ gefunden werden, die ein erstes Argument vom Typ „{0}“ akzeptiert (wollten Sie die asynchrone Sammlung mit „await foreach“ durchlaufen?)</target>
@@ -3000,6 +3015,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">Instanzmember in "nameof"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">Das diagnosticId-Argument für das Experimental-Attribut muss ein gültiger Bezeichner sein.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">„{0}“ enthält keine Definition für „{1}“, und es konnte keine zugängliche Erweiterungsmethode „{1}“ gefunden werden, die ein erstes Argument vom Typ „{0}“ akzeptiert (wollten Sie die asynchrone Sammlung mit „await foreach“ durchlaufen?)</target>
@@ -6683,6 +6668,11 @@
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">Keine einschließende Schleife, aus der angehalten und fortgefahren werden kann.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">El argumento diagnosticId del atributo "Experimental" debe ser un identificador válido.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">'{0}' no contiene una definición para '{1}' y no se encontró ningún método de extensión accesible '{1}' aceptando un primer argumento de tipo '{0}' (¿pretendía iterar por la colección asincrónica con 'await foreach' en su lugar?)</target>
@@ -6683,6 +6668,11 @@
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">No hay ningún bucle envolvente desde el que interrumpir o continuar</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">El argumento diagnosticId del atributo "Experimental" debe ser un identificador válido.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">'{0}' no contiene una definición para '{1}' y no se encontró ningún método de extensión accesible '{1}' aceptando un primer argumento de tipo '{0}' (¿pretendía iterar por la colección asincrónica con 'await foreach' en su lugar?)</target>
@@ -3000,6 +3015,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">miembro de instancia en 'nameof'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">L’argument diagnosticId de l’attribut « Experimental » doit être un identificateur valide</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">« {0} » ne contient pas de définition pour « {1} » et aucune méthode d’extension accessible « {1} » acceptant un premier argument de type « {0} » n’a pu être trouvée (vouliez-vous plutôt itérer la collection asynchrone avec « await foreach » ?)</target>
@@ -6683,6 +6668,11 @@
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">Absence de boucle englobant 'break' ou 'continue'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">L’argument diagnosticId de l’attribut « Experimental » doit être un identificateur valide</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">« {0} » ne contient pas de définition pour « {1} » et aucune méthode d’extension accessible « {1} » acceptant un premier argument de type « {0} » n’a pu être trouvée (vouliez-vous plutôt itérer la collection asynchrone avec « await foreach » ?)</target>
@@ -3000,6 +3015,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">membre d'instance dans 'nameof'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">L'argomento diagnosticId dell'attributo 'Experimental' deve essere un identificatore valido</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">'{0}' non contiene una definizione per '{1}' e non è possibile trovare alcun metodo di estensione accessibile '{1}' che accetta un primo argomento di tipo '{0}' (si intendeva forse eseguire l'iterazione sulla raccolta asincrona con 'await foreach'?)</target>
@@ -6683,6 +6668,11 @@ target:module               Compila un modulo che può essere aggiunto ad altro
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">Non esiste alcun ciclo di inclusione all'esterno del quale interrompere o continuare</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">L'argomento diagnosticId dell'attributo 'Experimental' deve essere un identificatore valido</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">'{0}' non contiene una definizione per '{1}' e non è possibile trovare alcun metodo di estensione accessibile '{1}' che accetta un primo argomento di tipo '{0}' (si intendeva forse eseguire l'iterazione sulla raccolta asincrona con 'await foreach'?)</target>
@@ -3000,6 +3015,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">membro di istanza in 'nameof'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">'Experimental' 属性への diagnosticId 引数は有効な識別子である必要があります</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">'{0}' に '{1}' の定義が含まれていません。また、型 '{0}' の最初の引数を受け入れるアクセス可能な拡張メソッド '{1}' が見つかりませんでした (代わりに 'await foreach' を使用して非同期コレクションを反復処理するつもりでしたか?)</target>
@@ -6683,6 +6668,11 @@
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">break または continue に対応するループがありません</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">'Experimental' 属性への diagnosticId 引数は有効な識別子である必要があります</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">'{0}' に '{1}' の定義が含まれていません。また、型 '{0}' の最初の引数を受け入れるアクセス可能な拡張メソッド '{1}' が見つかりませんでした (代わりに 'await foreach' を使用して非同期コレクションを反復処理するつもりでしたか?)</target>
@@ -3000,6 +3015,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">'nameof' のインスタンス メンバー</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">'Experimental' 특성에 대한 diagnosticId 인수는 유효한 식별자여야 합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">'{0}'에 '{1}'에 대한 정의가 없고, '{1}' 형식의 첫 번째 인수를 받는 액세스 가능한 확장 메서드 '{0}'을(를) 찾을 수 없습니다(대신 'await foreach'를 사용하여 비동기 컬렉션을 반복하려고 한 건가요?).</target>
@@ -6683,6 +6668,11 @@
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">break 또는 continue되어 빠져 나갈 루프가 없습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">'Experimental' 특성에 대한 diagnosticId 인수는 유효한 식별자여야 합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">'{0}'에 '{1}'에 대한 정의가 없고, '{1}' 형식의 첫 번째 인수를 받는 액세스 가능한 확장 메서드 '{0}'을(를) 찾을 수 없습니다(대신 'await foreach'를 사용하여 비동기 컬렉션을 반복하려고 한 건가요?).</target>
@@ -3000,6 +3015,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">'nameof'의 인스턴스 멤버</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">Argument diagnosticId atrybutu „Experimental” musi być prawidłowym identyfikatorem</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">„{0}” nie zawiera definicji dla „{1}” i nie znaleziono dostępnej metody rozszerzenia „{1}”, która przyjmowałaby pierwszy argument typu „{0}” (czy chodziło Ci o iterację kolekcji asynchronicznej za pomocą polecenia „await foreach”?)</target>
@@ -3000,6 +3015,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">składowa wystąpienia w elemencie „nameof”</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">Argument diagnosticId atrybutu „Experimental” musi być prawidłowym identyfikatorem</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">„{0}” nie zawiera definicji dla „{1}” i nie znaleziono dostępnej metody rozszerzenia „{1}”, która przyjmowałaby pierwszy argument typu „{0}” (czy chodziło Ci o iterację kolekcji asynchronicznej za pomocą polecenia „await foreach”?)</target>
@@ -6683,6 +6668,11 @@
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">Brak pętli otaczającej, w której ma nastąpić przerwanie lub kontynuowanie</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">O argumento diagnosticId para o atributo 'Experimental' deve ser um identificador válido</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">'{0}' não contém uma definição para '{1}' e nenhum método de extensão acessível '{1}' que aceite um primeiro argumento do tipo '{0}' pôde ser encontrado (você quis iterar sobre a coleção assíncrona usando 'await foreach'?)</target>
@@ -6683,6 +6668,11 @@
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">Nenhum loop delimitador a partir do qual quebrar ou continuar</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">O argumento diagnosticId para o atributo 'Experimental' deve ser um identificador válido</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">'{0}' não contém uma definição para '{1}' e nenhum método de extensão acessível '{1}' que aceite um primeiro argumento do tipo '{0}' pôde ser encontrado (você quis iterar sobre a coleção assíncrona usando 'await foreach'?)</target>
@@ -3000,6 +3015,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">membro da instância em 'nameof'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">Аргумент diagnosticId атрибута "Experimental" должен быть допустимым идентификатором</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">"{0}" не содержит определение для "{1}", не найден доступный метод расширения "{1}", принимающий первый аргумент типа "{0}" (возможно, нужно было выполнить итерацию для синхронной коллекции с помощью "await foreach"?)</target>
@@ -6683,6 +6668,11 @@
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">Отсутствует внешний цикл для прерывания или продолжения.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">Аргумент diagnosticId атрибута "Experimental" должен быть допустимым идентификатором</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">"{0}" не содержит определение для "{1}", не найден доступный метод расширения "{1}", принимающий первый аргумент типа "{0}" (возможно, нужно было выполнить итерацию для синхронной коллекции с помощью "await foreach"?)</target>
@@ -3000,6 +3015,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">элемент экземпляра в "nameof"</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">'Experimental' özniteliğinin diagnosticId bağımsız değişkeni geçerli bir tanımlayıcı olmalıdır</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">' {0}' '{1}' için bir tanım içermiyor ve '{0}' türünden ilk bağımsız değişkeni kabul eden erişilebilir '{1}' uzantı yöntemi bulunamadı (zaman uyumsuz koleksiyon üzerinde 'await foreach' ile yineleme yapmak mı istediniz?)</target>
@@ -6683,6 +6668,11 @@
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">Durdurulacak veya devam ettirilecek kapsayan bir döngü yok</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">'Experimental' özniteliğinin diagnosticId bağımsız değişkeni geçerli bir tanımlayıcı olmalıdır</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">' {0}' '{1}' için bir tanım içermiyor ve '{0}' türünden ilk bağımsız değişkeni kabul eden erişilebilir '{1}' uzantı yöntemi bulunamadı (zaman uyumsuz koleksiyon üzerinde 'await foreach' ile yineleme yapmak mı istediniz?)</target>
@@ -3000,6 +3015,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">'nameof' içinde örnek üyesi</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">“Experimental” 属性的 diagnosticId 参数必须是有效的标识符</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">“{0}”不包含“{1}”的定义，且找不到任何可访问的扩展方法“{1}”，其中该方法接受类型为“{0}”的第一个参数(是否想用 "await foreach" 来循环访问异步集合?)</target>
@@ -3000,6 +3015,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">"nameof" 中的实例成员</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">“Experimental” 属性的 diagnosticId 参数必须是有效的标识符</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">“{0}”不包含“{1}”的定义，且找不到任何可访问的扩展方法“{1}”，其中该方法接受类型为“{0}”的第一个参数(是否想用 "await foreach" 来循环访问异步集合?)</target>
@@ -6683,6 +6668,11 @@
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">没有要中断或继续的封闭循环</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1482,6 +1482,21 @@
         <target state="translated">'Experimental' 屬性的 diagnosticId 引數必須是有效的識別碼</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
+        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
+        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
+        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_LabeledContinueNotOnLoop">
+        <source>The label '{0}' does not refer to a containing loop statement</source>
+        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">'{0}' 不包含 '{1}' 的定義，而且找不到接受類型 '{0}' 的第一個引數的可存取方法 '{1}' (您是否要改為使用 'await foreach' 來逐一查看非同步集合?)</target>
@@ -3000,6 +3015,11 @@
       <trans-unit id="IDS_FeatureInstanceMemberInNameof">
         <source>instance member in 'nameof'</source>
         <target state="translated">'nameof' 中的執行個體成員</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IDS_FeatureLabeledBreakContinue">
+        <source>labeled break and continue</source>
+        <target state="new">labeled break and continue</target>
         <note />
       </trans-unit>
       <trans-unit id="IDS_FeatureLambdaAttributes">

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -1482,21 +1482,6 @@
         <target state="translated">'Experimental' 屬性的 diagnosticId 引數必須是有效的識別碼</target>
         <note />
       </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotContaining">
-        <source>The label '{0}' does not refer to a statement that contains this break or continue statement</source>
-        <target state="new">The label '{0}' does not refer to a statement that contains this break or continue statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledBreakContinueNotOnLoopOrSwitch">
-        <source>The label '{0}' does not refer to a containing loop or switch statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop or switch statement</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ERR_LabeledContinueNotOnLoop">
-        <source>The label '{0}' does not refer to a containing loop statement</source>
-        <target state="new">The label '{0}' does not refer to a containing loop statement</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ERR_NoAwaitOnAsyncEnumerable">
         <source>'{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (did you mean to iterate over the async collection with 'await foreach' instead?)</source>
         <target state="translated">'{0}' 不包含 '{1}' 的定義，而且找不到接受類型 '{0}' 的第一個引數的可存取方法 '{1}' (您是否要改為使用 'await foreach' 來逐一查看非同步集合?)</target>
@@ -6683,6 +6668,11 @@ strument:TestCoverage      產生檢測要收集
       <trans-unit id="ERR_NoBreakOrCont">
         <source>No enclosing loop out of which to break or continue</source>
         <target state="translated">沒有可中斷或繼續的封閉式迴圈</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ERR_NoBreakOrContId">
+        <source>No enclosing loop or switch statement with the label '{0}' out of which to break or continue</source>
+        <target state="new">No enclosing loop or switch statement with the label '{0}' out of which to break or continue</target>
         <note />
       </trans-unit>
       <trans-unit id="ERR_DuplicateLabel">

--- a/src/Compilers/CSharp/Test/CSharp15/LabeledBreakContinueBindingTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/LabeledBreakContinueBindingTests.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.CSharp.UnitTests;
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
 
 public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
 {
@@ -32,10 +32,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -54,10 +51,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -75,10 +69,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: do
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -97,10 +88,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: do
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -120,9 +108,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: for (int i = 0; i < 10; i++)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
             // (7,37): warning CS0162: Unreachable code detected
             //             for (int j = 0; j < 10; j++)
             Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(7, 37));
@@ -145,9 +130,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: for (int i = 0; i < 10; i++)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
             // (7,37): warning CS0162: Unreachable code detected
             //             for (int j = 0; j < 10; j++)
             Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(7, 37));
@@ -169,10 +151,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: foreach (var a in args)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -191,10 +170,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: foreach (var a in args)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -213,10 +189,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: foreach (var (x, y) in items)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     #endregion
@@ -240,10 +213,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: switch (x)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -265,10 +235,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -291,10 +258,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: switch (x)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     #endregion
@@ -357,15 +321,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         L0: while (a-- > 0)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L0").WithLocation(5, 9),
-            // (7,13): warning CS0164: This label has not been referenced
-            //             L1: switch (b)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L1").WithLocation(7, 13),
-            // (10,21): warning CS0164: This label has not been referenced
-            //                     L2: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L2").WithLocation(10, 21),
             // (16,21): warning CS0162: Unreachable code detected
             //                     break;
             Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(16, 21));
@@ -394,10 +349,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -419,9 +371,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: for (int i = 0; i < 10; i++)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
             // (5,40): warning CS0162: Unreachable code detected
             //         outer: for (int i = 0; i < 10; i++)
             Diagnostic(ErrorCode.WRN_UnreachableCode, "i").WithLocation(5, 40));
@@ -446,10 +395,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -473,10 +419,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -500,9 +443,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (6,9): warning CS0164: This label has not been referenced
-            //         outer: for (int i = 0; i < 1; i++)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(6, 9),
             // (8,36): warning CS0162: Unreachable code detected
             //             for (int j = 0; j < 1; j++)
             Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(8, 36));
@@ -525,10 +465,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (6,9): warning CS0164: This label has not been referenced
-            //         outer: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(6, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -569,10 +506,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         L: for (;;)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     [Fact]
@@ -590,10 +524,185 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
+        CreateCompilation(source).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Break_UnreachableLabeledBreak_StillSuppressesWarning()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        break;
+                        break outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (8,13): warning CS0162: Unreachable code detected
+            //             break outer;
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(8, 13));
+    }
+
+    [Fact]
+    public void Continue_UnreachableLabeledContinue_StillSuppressesWarning()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        break;
+                        continue outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (8,13): warning CS0162: Unreachable code detected
+            //             continue outer;
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "continue").WithLocation(8, 13));
+    }
+
+    [Fact]
+    public void Break_StackedLabels_OnlyValidLabelReferenced()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    a: b: c: while (true)
+                    {
+                        break c;
+                    }
+                }
+            }
+            """;
         CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
-            //         \u006Futer: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, @"\u006Futer").WithLocation(5, 9));
+            //         a: b: c: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "a").WithLocation(5, 9),
+            // (5,12): warning CS0164: This label has not been referenced
+            //         a: b: c: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "b").WithLocation(5, 12));
+    }
+
+    [Fact]
+    public void Break_MultipleLabeledBreaksToSameLabel()
+    {
+        var source = """
+            class C
+            {
+                void M(bool x)
+                {
+                    outer: while (true)
+                    {
+                        if (x)
+                            break outer;
+                        else
+                            break outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Continue_MultipleLabeledContinuesToSameLabel()
+    {
+        var source = """
+            class C
+            {
+                void M(bool x)
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        if (x)
+                            continue outer;
+                        else
+                            continue outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Break_MixedUnlabeledAndLabeledExits()
+    {
+        var source = """
+            class C
+            {
+                void M(bool cond)
+                {
+                    outer: while (true)
+                    {
+                        while (cond)
+                            break;
+                        break outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Break_LabeledBreakFirst_GotoUnreachable()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    L: while (true)
+                    {
+                        break L;
+                        goto L;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (8,13): warning CS0162: Unreachable code detected
+            //             goto L;
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "goto").WithLocation(8, 13));
+    }
+
+    [Fact]
+    public void Break_InCatch_WithFinally_TargetsOuterLoop()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        try
+                        {
+                            throw new System.Exception();
+                        }
+                        catch
+                        {
+                            break outer;
+                        }
+                        finally { }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     #endregion
@@ -1091,6 +1200,104 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             Diagnostic(ErrorCode.ERR_NoBreakOrContId, "outer").WithArguments("outer").WithLocation(7, 15));
     }
 
+    [Fact]
+    public void Break_InsideLambda_TargetsLoopInsideLambda()
+    {
+        var source = """
+            using System;
+            class C
+            {
+                void M()
+                {
+                    Action a = () =>
+                    {
+                        outer: while (true)
+                        {
+                            while (true)
+                                break outer;
+                        }
+                    };
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Continue_InsideLambda_TargetsLoopInsideLambda()
+    {
+        var source = """
+            using System;
+            class C
+            {
+                void M()
+                {
+                    Action a = () =>
+                    {
+                        outer: for (int i = 0; i < 10; i++)
+                        {
+                            for (int j = 0; j < 10; j++)
+                                continue outer;
+                        }
+                    };
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (10,41): warning CS0162: Unreachable code detected
+            //                     for (int j = 0; j < 10; j++)
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(10, 41));
+    }
+
+    [Fact]
+    public void Break_InsideLocalFunction_TargetsLoopInsideLocalFunction()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    void F()
+                    {
+                        outer: while (true)
+                        {
+                            while (true)
+                                break outer;
+                        }
+                    }
+                    F();
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Continue_InsideLocalFunction_TargetsLoopInsideLocalFunction()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    void F()
+                    {
+                        outer: for (int i = 0; i < 10; i++)
+                        {
+                            for (int j = 0; j < 10; j++)
+                                continue outer;
+                        }
+                    }
+                    F();
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (9,41): warning CS0162: Unreachable code detected
+            //                     for (int j = 0; j < 10; j++)
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(9, 41));
+    }
+
     #endregion
 
     #region Finally blocks
@@ -1112,9 +1319,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: for (int i = 0; i < 10; i++)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
             // (5,40): warning CS0162: Unreachable code detected
             //         outer: for (int i = 0; i < 10; i++)
             Diagnostic(ErrorCode.WRN_UnreachableCode, "i").WithLocation(5, 40),
@@ -1140,12 +1344,58 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: for (int i = 0; i < 10; i++)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
             // (8,23): error CS0157: Control cannot leave the body of a finally clause
             //             finally { continue outer; }
             Diagnostic(ErrorCode.ERR_BadFinallyLeave, "continue").WithLocation(8, 23));
+    }
+
+    [Fact]
+    public void Break_InFinally_TargetsLoopInsideFinally()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    try { }
+                    finally
+                    {
+                        outer: while (true)
+                        {
+                            while (true)
+                                break outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics();
+    }
+
+    [Fact]
+    public void Continue_InFinally_TargetsLoopInsideFinally()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    try { }
+                    finally
+                    {
+                        outer: for (int i = 0; i < 10; i++)
+                        {
+                            for (int j = 0; j < 10; j++)
+                                continue outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (10,41): warning CS0162: Unreachable code detected
+            //                     for (int j = 0; j < 10; j++)
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(10, 41));
     }
 
     [Fact]
@@ -1164,10 +1414,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+        CreateCompilation(source).VerifyDiagnostics();
     }
 
     #endregion
@@ -1188,9 +1435,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
             // (6,19): error CS8652: The feature 'labeled break and continue' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //             break outer;
             Diagnostic(ErrorCode.ERR_FeatureInPreview, "outer").WithArguments("labeled break and continue").WithLocation(6, 19));
@@ -1213,9 +1457,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: for (int i = 0; i < 10; i++)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
             // (7,37): warning CS0162: Unreachable code detected
             //             for (int j = 0; j < 10; j++)
             Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(7, 37),
@@ -1236,12 +1477,43 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 break outer;
             """;
         CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
-            // (1,1): warning CS0164: This label has not been referenced
-            // outer: for (int i = 0; i < 1; i++)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(1, 1),
             // (1,31): warning CS0162: Unreachable code detected
             // outer: for (int i = 0; i < 1; i++)
             Diagnostic(ErrorCode.WRN_UnreachableCode, "i").WithLocation(1, 31));
+    }
+
+    [Fact]
+    public void Continue_TopLevelStatements()
+    {
+        var source = """
+            outer: for (int i = 0; i < 10; i++)
+            {
+                for (int j = 0; j < 10; j++)
+                    continue outer;
+            }
+            """;
+        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+            // (3,29): warning CS0162: Unreachable code detected
+            //     for (int j = 0; j < 10; j++)
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(3, 29));
+    }
+
+    [Fact]
+    public void Break_TopLevelStatements_Switch()
+    {
+        var source = """
+            int x = 0;
+            outer: switch (x)
+            {
+                case 0:
+                    switch (x)
+                    {
+                        case 0: break outer;
+                    }
+                    break;
+            }
+            """;
+        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics();
     }
 
     #endregion

--- a/src/Compilers/CSharp/Test/CSharp15/LabeledBreakContinueEmitTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/LabeledBreakContinueEmitTests.cs
@@ -1,0 +1,1095 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+public sealed class LabeledBreakContinueEmitTests : CSharpTestBase
+{
+    #region while
+
+    [Fact]
+    public void Break_While_Immediate()
+    {
+        var source = """
+            outer: while (true)
+            {
+                System.Console.Write("A ");
+                break outer;
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "A done");
+    }
+
+    [Fact]
+    public void Break_While_Nested()
+    {
+        var source = """
+            outer: while (true)
+            {
+                while (true)
+                {
+                    System.Console.Write("A ");
+                    break outer;
+                }
+                System.Console.Write("SKIPPED ");
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "A done");
+    }
+
+    [Fact]
+    public void Continue_While_Immediate()
+    {
+        var source = """
+            int i = 0;
+            outer: while (i < 3)
+            {
+                i++;
+                System.Console.Write(i + " ");
+                continue outer;
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "1 2 3 done");
+    }
+
+    [Fact]
+    public void Continue_While_Nested()
+    {
+        var source = """
+            int i = 0;
+            outer: while (i < 3)
+            {
+                i++;
+                while (true)
+                {
+                    System.Console.Write(i + " ");
+                    continue outer;
+                }
+                System.Console.Write("SKIPPED ");
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "1 2 3 done");
+    }
+
+    #endregion
+
+    #region do/while
+
+    [Fact]
+    public void Break_DoWhile_Immediate()
+    {
+        var source = """
+            outer: do
+            {
+                System.Console.Write("A ");
+                break outer;
+            } while (true);
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "A done");
+    }
+
+    [Fact]
+    public void Break_DoWhile_Nested()
+    {
+        var source = """
+            outer: do
+            {
+                do
+                {
+                    System.Console.Write("A ");
+                    break outer;
+                } while (true);
+                System.Console.Write("SKIPPED ");
+            } while (true);
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "A done");
+    }
+
+    [Fact]
+    public void Continue_DoWhile_Immediate()
+    {
+        var source = """
+            int i = 0;
+            outer: do
+            {
+                i++;
+                System.Console.Write(i + " ");
+                continue outer;
+            } while (i < 3);
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "1 2 3 done");
+    }
+
+    [Fact]
+    public void Continue_DoWhile_Nested()
+    {
+        var source = """
+            int i = 0;
+            outer: do
+            {
+                i++;
+                while (true)
+                {
+                    System.Console.Write(i + " ");
+                    continue outer;
+                }
+                System.Console.Write("SKIPPED ");
+            } while (i < 3);
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "1 2 3 done");
+    }
+
+    #endregion
+
+    #region for
+
+    [Fact]
+    public void Break_For_Immediate()
+    {
+        var source = """
+            outer: for (int i = 0; ; i++)
+            {
+                System.Console.Write(i + " ");
+                break outer;
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "0 done");
+    }
+
+    [Fact]
+    public void Break_For_Nested()
+    {
+        var source = """
+            outer: for (int i = 0; i < 3; i++)
+            {
+                for (int j = 0; ; j++)
+                {
+                    System.Console.Write($"({i},{j}) ");
+                    break outer;
+                }
+                System.Console.Write("SKIPPED ");
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "(0,0) done");
+    }
+
+    [Fact]
+    public void Continue_For_Immediate()
+    {
+        var source = """
+            outer: for (int i = 0; i < 3; i++)
+            {
+                System.Console.Write(i + " ");
+                continue outer;
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "0 1 2 done");
+    }
+
+    [Fact]
+    public void Continue_For_Nested()
+    {
+        var source = """
+            outer: for (int i = 0; i < 3; i++)
+            {
+                for (int j = 0; ; j++)
+                {
+                    System.Console.Write($"({i},{j}) ");
+                    continue outer;
+                }
+                System.Console.Write("SKIPPED ");
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "(0,0) (1,0) (2,0) done");
+    }
+
+    #endregion
+
+    #region foreach
+
+    [Fact]
+    public void Break_ForEach_Immediate()
+    {
+        var source = """
+            outer: foreach (var x in new[] { 1, 2, 3 })
+            {
+                System.Console.Write(x + " ");
+                break outer;
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "1 done");
+    }
+
+    [Fact]
+    public void Break_ForEach_Nested()
+    {
+        var source = """
+            outer: foreach (var x in new[] { 1, 2, 3 })
+            {
+                foreach (var y in new[] { 10, 20 })
+                {
+                    System.Console.Write($"{x}+{y} ");
+                    break outer;
+                }
+                System.Console.Write("SKIPPED ");
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "1+10 done");
+    }
+
+    [Fact]
+    public void Continue_ForEach_Immediate()
+    {
+        var source = """
+            outer: foreach (var x in new[] { 1, 2, 3 })
+            {
+                System.Console.Write(x + " ");
+                continue outer;
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "1 2 3 done");
+    }
+
+    [Fact]
+    public void Continue_ForEach_Nested()
+    {
+        var source = """
+            outer: foreach (var x in new[] { 1, 2, 3 })
+            {
+                foreach (var y in new[] { 10, 20 })
+                {
+                    System.Console.Write($"{x}+{y} ");
+                    continue outer;
+                }
+                System.Console.Write("SKIPPED ");
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "1+10 2+10 3+10 done");
+    }
+
+    #endregion
+
+    #region switch
+
+    [Fact]
+    public void Break_Switch_Immediate()
+    {
+        var source = """
+            int x = 1;
+            outer: switch (x)
+            {
+                case 1:
+                    System.Console.Write("case1 ");
+                    break outer;
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "case1 done");
+    }
+
+    [Fact]
+    public void Break_Switch_Nested()
+    {
+        var source = """
+            outer: while (true)
+            {
+                switch (1)
+                {
+                    case 1:
+                        System.Console.Write("inner ");
+                        break outer;
+                }
+                System.Console.Write("SKIPPED ");
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "inner done");
+    }
+
+    [Fact]
+    public void Break_Switch_FromNestedSwitch()
+    {
+        var source = """
+            outer: switch (1)
+            {
+                case 1:
+                    switch (2)
+                    {
+                        case 2:
+                            System.Console.Write("nested ");
+                            break outer;
+                    }
+                    System.Console.Write("SKIPPED ");
+                    break;
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "nested done");
+    }
+
+    [Fact]
+    public void Continue_For_FromSwitch()
+    {
+        var source = """
+            outer: for (int i = 0; i < 3; i++)
+            {
+                switch (i)
+                {
+                    case 0:
+                        System.Console.Write("zero ");
+                        continue outer;
+                    case 1:
+                        System.Console.Write("one ");
+                        continue outer;
+                    default:
+                        System.Console.Write("other ");
+                        continue outer;
+                }
+                System.Console.Write("SKIPPED ");
+            }
+            System.Console.Write("done");
+            """;
+        CompileAndVerify(source, expectedOutput: "zero one other done");
+    }
+
+    #endregion
+
+    #region IL verification
+
+    [Fact]
+    public void IL_Break_While_Nested()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b1, bool b2)
+                {
+                    outer: while (b1)
+                    {
+                        while (b2)
+                        {
+                            break outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size        9 (0x9)
+              .maxstack  1
+              IL_0000:  br.s       IL_0005
+              IL_0002:  ldarg.1
+              IL_0003:  brtrue.s   IL_0008
+              IL_0005:  ldarg.0
+              IL_0006:  brtrue.s   IL_0002
+              IL_0008:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Break_While_Nested_Conditional()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b1, bool b2, bool b3)
+                {
+                    outer: while (b1)
+                    {
+                        while (b2)
+                        {
+                            if (b3) break outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size       12 (0xc)
+              .maxstack  1
+              IL_0000:  br.s       IL_0008
+              IL_0002:  ldarg.2
+              IL_0003:  brtrue.s   IL_000b
+              IL_0005:  ldarg.1
+              IL_0006:  brtrue.s   IL_0002
+              IL_0008:  ldarg.0
+              IL_0009:  brtrue.s   IL_0005
+              IL_000b:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Continue_While_Immediate()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b)
+                {
+                    outer: while (b)
+                    {
+                        continue outer;
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size        4 (0x4)
+              .maxstack  1
+              IL_0000:  ldarg.0
+              IL_0001:  brtrue.s   IL_0000
+              IL_0003:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Continue_While_Nested()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b1, bool b2)
+                {
+                    outer: while (b1)
+                    {
+                        while (b2)
+                        {
+                            continue outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size        8 (0x8)
+              .maxstack  1
+              IL_0000:  br.s       IL_0004
+              IL_0002:  ldarg.1
+              IL_0003:  pop
+              IL_0004:  ldarg.0
+              IL_0005:  brtrue.s   IL_0002
+              IL_0007:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Continue_While_Nested_Conditional()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b1, bool b2, bool b3)
+                {
+                    outer: while (b1)
+                    {
+                        while (b2)
+                        {
+                            if (b3) continue outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size       12 (0xc)
+              .maxstack  1
+              IL_0000:  br.s       IL_0008
+              IL_0002:  ldarg.2
+              IL_0003:  brtrue.s   IL_0008
+              IL_0005:  ldarg.1
+              IL_0006:  brtrue.s   IL_0002
+              IL_0008:  ldarg.0
+              IL_0009:  brtrue.s   IL_0005
+              IL_000b:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Break_DoWhile_Nested()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b1, bool b2)
+                {
+                    outer: do
+                    {
+                        do
+                        {
+                            break outer;
+                        } while (b2);
+                    } while (b1);
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size        1 (0x1)
+              .maxstack  1
+              IL_0000:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Break_DoWhile_Nested_Conditional()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b1, bool b2, bool b3)
+                {
+                    outer: do
+                    {
+                        do
+                        {
+                            if (b3) break outer;
+                        } while (b2);
+                    } while (b1);
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size       10 (0xa)
+              .maxstack  1
+              IL_0000:  ldarg.2
+              IL_0001:  brtrue.s   IL_0009
+              IL_0003:  ldarg.1
+              IL_0004:  brtrue.s   IL_0000
+              IL_0006:  ldarg.0
+              IL_0007:  brtrue.s   IL_0000
+              IL_0009:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Continue_DoWhile_Immediate()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b)
+                {
+                    outer: do
+                    {
+                        continue outer;
+                    } while (b);
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size        4 (0x4)
+              .maxstack  1
+              IL_0000:  ldarg.0
+              IL_0001:  brtrue.s   IL_0000
+              IL_0003:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Continue_DoWhile_Nested()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b1, bool b2)
+                {
+                    outer: do
+                    {
+                        do
+                        {
+                            continue outer;
+                        } while (b2);
+                    } while (b1);
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size        4 (0x4)
+              .maxstack  1
+              IL_0000:  ldarg.0
+              IL_0001:  brtrue.s   IL_0000
+              IL_0003:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Continue_DoWhile_Nested_Conditional()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b1, bool b2, bool b3)
+                {
+                    outer: do
+                    {
+                        do
+                        {
+                            if (b3) continue outer;
+                        } while (b2);
+                    } while (b1);
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size       10 (0xa)
+              .maxstack  1
+              IL_0000:  ldarg.2
+              IL_0001:  brtrue.s   IL_0006
+              IL_0003:  ldarg.1
+              IL_0004:  brtrue.s   IL_0000
+              IL_0006:  ldarg.0
+              IL_0007:  brtrue.s   IL_0000
+              IL_0009:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Break_For_Nested()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b)
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        for (int j = 0; b; j++)
+                        {
+                            break outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size       19 (0x13)
+              .maxstack  2
+              .locals init (int V_0, //i
+                           int V_1) //j
+              IL_0000:  ldc.i4.0
+              IL_0001:  stloc.0
+              IL_0002:  br.s       IL_000d
+              IL_0004:  ldc.i4.0
+              IL_0005:  stloc.1
+              IL_0006:  ldarg.0
+              IL_0007:  brtrue.s   IL_0012
+              IL_0009:  ldloc.0
+              IL_000a:  ldc.i4.1
+              IL_000b:  add
+              IL_000c:  stloc.0
+              IL_000d:  ldloc.0
+              IL_000e:  ldc.i4.s   10
+              IL_0010:  blt.s      IL_0004
+              IL_0012:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Break_For_Nested_Conditional()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b1, bool b2)
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        for (int j = 0; b1; j++)
+                        {
+                            if (b2) break outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size       28 (0x1c)
+              .maxstack  2
+              .locals init (int V_0, //i
+                           int V_1) //j
+              IL_0000:  ldc.i4.0
+              IL_0001:  stloc.0
+              IL_0002:  br.s       IL_0016
+              IL_0004:  ldc.i4.0
+              IL_0005:  stloc.1
+              IL_0006:  br.s       IL_000f
+              IL_0008:  ldarg.1
+              IL_0009:  brtrue.s   IL_001b
+              IL_000b:  ldloc.1
+              IL_000c:  ldc.i4.1
+              IL_000d:  add
+              IL_000e:  stloc.1
+              IL_000f:  ldarg.0
+              IL_0010:  brtrue.s   IL_0008
+              IL_0012:  ldloc.0
+              IL_0013:  ldc.i4.1
+              IL_0014:  add
+              IL_0015:  stloc.0
+              IL_0016:  ldloc.0
+              IL_0017:  ldc.i4.s   10
+              IL_0019:  blt.s      IL_0004
+              IL_001b:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Continue_For_Immediate()
+    {
+        var source = """
+            class C
+            {
+                static void M()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        continue outer;
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size       14 (0xe)
+              .maxstack  2
+              .locals init (int V_0) //i
+              IL_0000:  ldc.i4.0
+              IL_0001:  stloc.0
+              IL_0002:  br.s       IL_0008
+              IL_0004:  ldloc.0
+              IL_0005:  ldc.i4.1
+              IL_0006:  add
+              IL_0007:  stloc.0
+              IL_0008:  ldloc.0
+              IL_0009:  ldc.i4.s   10
+              IL_000b:  blt.s      IL_0004
+              IL_000d:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Continue_For_Nested()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b)
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        for (int j = 0; b; j++)
+                        {
+                            continue outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size       18 (0x12)
+              .maxstack  2
+              .locals init (int V_0, //i
+                           int V_1) //j
+              IL_0000:  ldc.i4.0
+              IL_0001:  stloc.0
+              IL_0002:  br.s       IL_000c
+              IL_0004:  ldc.i4.0
+              IL_0005:  stloc.1
+              IL_0006:  ldarg.0
+              IL_0007:  pop
+              IL_0008:  ldloc.0
+              IL_0009:  ldc.i4.1
+              IL_000a:  add
+              IL_000b:  stloc.0
+              IL_000c:  ldloc.0
+              IL_000d:  ldc.i4.s   10
+              IL_000f:  blt.s      IL_0004
+              IL_0011:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Continue_For_Nested_Conditional()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b1, bool b2)
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        for (int j = 0; b1; j++)
+                        {
+                            if (b2) continue outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size       28 (0x1c)
+              .maxstack  2
+              .locals init (int V_0, //i
+                           int V_1) //j
+              IL_0000:  ldc.i4.0
+              IL_0001:  stloc.0
+              IL_0002:  br.s       IL_0016
+              IL_0004:  ldc.i4.0
+              IL_0005:  stloc.1
+              IL_0006:  br.s       IL_000f
+              IL_0008:  ldarg.1
+              IL_0009:  brtrue.s   IL_0012
+              IL_000b:  ldloc.1
+              IL_000c:  ldc.i4.1
+              IL_000d:  add
+              IL_000e:  stloc.1
+              IL_000f:  ldarg.0
+              IL_0010:  brtrue.s   IL_0008
+              IL_0012:  ldloc.0
+              IL_0013:  ldc.i4.1
+              IL_0014:  add
+              IL_0015:  stloc.0
+              IL_0016:  ldloc.0
+              IL_0017:  ldc.i4.s   10
+              IL_0019:  blt.s      IL_0004
+              IL_001b:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Break_ForEach_Nested()
+    {
+        var source = """
+            class C
+            {
+                static void M(int[] a, int[] b)
+                {
+                    outer: foreach (var x in a)
+                    {
+                        foreach (var y in b)
+                        {
+                            break outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size       38 (0x26)
+              .maxstack  2
+              .locals init (int[] V_0,
+                           int V_1,
+                           int[] V_2,
+                           int V_3)
+              IL_0000:  ldarg.0
+              IL_0001:  stloc.0
+              IL_0002:  ldc.i4.0
+              IL_0003:  stloc.1
+              IL_0004:  br.s       IL_001f
+              IL_0006:  ldloc.0
+              IL_0007:  ldloc.1
+              IL_0008:  ldelem.i4
+              IL_0009:  pop
+              IL_000a:  ldarg.1
+              IL_000b:  stloc.2
+              IL_000c:  ldc.i4.0
+              IL_000d:  stloc.3
+              IL_000e:  br.s       IL_0015
+              IL_0010:  ldloc.2
+              IL_0011:  ldloc.3
+              IL_0012:  ldelem.i4
+              IL_0013:  pop
+              IL_0014:  ret
+              IL_0015:  ldloc.3
+              IL_0016:  ldloc.2
+              IL_0017:  ldlen
+              IL_0018:  conv.i4
+              IL_0019:  blt.s      IL_0010
+              IL_001b:  ldloc.1
+              IL_001c:  ldc.i4.1
+              IL_001d:  add
+              IL_001e:  stloc.1
+              IL_001f:  ldloc.1
+              IL_0020:  ldloc.0
+              IL_0021:  ldlen
+              IL_0022:  conv.i4
+              IL_0023:  blt.s      IL_0006
+              IL_0025:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Continue_ForEach_Nested()
+    {
+        var source = """
+            class C
+            {
+                static void M(int[] a, int[] b)
+                {
+                    outer: foreach (var x in a)
+                    {
+                        foreach (var y in b)
+                        {
+                            continue outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size       39 (0x27)
+              .maxstack  2
+              .locals init (int[] V_0,
+                           int V_1,
+                           int[] V_2,
+                           int V_3)
+              IL_0000:  ldarg.0
+              IL_0001:  stloc.0
+              IL_0002:  ldc.i4.0
+              IL_0003:  stloc.1
+              IL_0004:  br.s       IL_0020
+              IL_0006:  ldloc.0
+              IL_0007:  ldloc.1
+              IL_0008:  ldelem.i4
+              IL_0009:  pop
+              IL_000a:  ldarg.1
+              IL_000b:  stloc.2
+              IL_000c:  ldc.i4.0
+              IL_000d:  stloc.3
+              IL_000e:  br.s       IL_0016
+              IL_0010:  ldloc.2
+              IL_0011:  ldloc.3
+              IL_0012:  ldelem.i4
+              IL_0013:  pop
+              IL_0014:  br.s       IL_001c
+              IL_0016:  ldloc.3
+              IL_0017:  ldloc.2
+              IL_0018:  ldlen
+              IL_0019:  conv.i4
+              IL_001a:  blt.s      IL_0010
+              IL_001c:  ldloc.1
+              IL_001d:  ldc.i4.1
+              IL_001e:  add
+              IL_001f:  stloc.1
+              IL_0020:  ldloc.1
+              IL_0021:  ldloc.0
+              IL_0022:  ldlen
+              IL_0023:  conv.i4
+              IL_0024:  blt.s      IL_0006
+              IL_0026:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Break_Switch_Immediate()
+    {
+        var source = """
+            class C
+            {
+                static void M(int x)
+                {
+                    outer: switch (x)
+                    {
+                        case 0: break outer;
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size        3 (0x3)
+              .maxstack  1
+              IL_0000:  ldarg.0
+              IL_0001:  pop
+              IL_0002:  ret
+            }
+            """);
+    }
+
+    [Fact]
+    public void IL_Break_Switch_FromWhile()
+    {
+        var source = """
+            class C
+            {
+                static void M(bool b, int x)
+                {
+                    outer: while (b)
+                    {
+                        switch (x)
+                        {
+                            case 0: break outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CompileAndVerify(source).VerifyIL("C.M", """
+            {
+              // Code size        9 (0x9)
+              .maxstack  1
+              IL_0000:  br.s       IL_0005
+              IL_0002:  ldarg.1
+              IL_0003:  brfalse.s  IL_0008
+              IL_0005:  ldarg.0
+              IL_0006:  brtrue.s   IL_0002
+              IL_0008:  ret
+            }
+            """);
+    }
+
+    #endregion
+}

--- a/src/Compilers/CSharp/Test/CSharp15/LabeledBreakContinueIOperationTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/LabeledBreakContinueIOperationTests.cs
@@ -1,0 +1,453 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+public sealed class LabeledBreakContinueIOperationTests : SemanticModelTestBase
+{
+    #region GetCorrespondingOperation — labeled break/continue targeting immediate construct
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledBreak_ImmediateWhile()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: while (true)
+                    {
+                        /*<bind>*/break outer;/*</bind>*/
+                    }
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<BreakStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<IWhileLoopOperation>(corresponding);
+    }
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledContinue_ImmediateWhile()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: while (true)
+                    {
+                        /*<bind>*/continue outer;/*</bind>*/
+                    }
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<ContinueStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<IWhileLoopOperation>(corresponding);
+    }
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledBreak_ImmediateFor()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        /*<bind>*/break outer;/*</bind>*/
+                    }
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<BreakStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<IForLoopOperation>(corresponding);
+    }
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledContinue_ImmediateForEach()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: foreach (var x in new[] { 1 })
+                    {
+                        /*<bind>*/continue outer;/*</bind>*/
+                    }
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<ContinueStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<IForEachLoopOperation>(corresponding);
+    }
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledBreak_ImmediateDoWhile()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: do
+                    {
+                        /*<bind>*/break outer;/*</bind>*/
+                    } while (true);
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<BreakStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<IWhileLoopOperation>(corresponding);
+    }
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledBreak_ImmediateSwitch()
+    {
+        var source = """
+            class C
+            {
+                void F(int x)
+                {
+                    outer: switch (x)
+                    {
+                        case 0:
+                            /*<bind>*/break outer;/*</bind>*/
+                    }
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<BreakStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<ISwitchOperation>(corresponding);
+    }
+
+    #endregion
+
+    #region GetCorrespondingOperation — labeled break/continue targeting outer construct (skipping inner)
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledBreak_OuterWhile_SkipsInnerWhile()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: while (true)
+                    {
+                        while (true)
+                        {
+                            /*<bind>*/break outer;/*</bind>*/
+                        }
+                    }
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<BreakStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<IWhileLoopOperation>(corresponding);
+        var whileOp = (IWhileLoopOperation)corresponding;
+        Assert.Equal("while (true)", whileOp.Syntax.ToString().Split('\n')[0].Trim());
+    }
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledContinue_OuterFor_SkipsInnerWhile()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        while (true)
+                        {
+                            /*<bind>*/continue outer;/*</bind>*/
+                        }
+                    }
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<ContinueStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<IForLoopOperation>(corresponding);
+    }
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledBreak_OuterWhile_SkipsInnerSwitch()
+    {
+        var source = """
+            class C
+            {
+                void F(int x)
+                {
+                    outer: while (true)
+                    {
+                        switch (x)
+                        {
+                            case 0:
+                                /*<bind>*/break outer;/*</bind>*/
+                        }
+                    }
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<BreakStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<IWhileLoopOperation>(corresponding);
+    }
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledBreak_OuterSwitch_SkipsInnerSwitch()
+    {
+        var source = """
+            class C
+            {
+                void F(int x)
+                {
+                    outer: switch (x)
+                    {
+                        case 0:
+                            switch (x)
+                            {
+                                case 1:
+                                    /*<bind>*/break outer;/*</bind>*/
+                            }
+                            break;
+                    }
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<BreakStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<ISwitchOperation>(corresponding);
+        var switchOp = (ISwitchOperation)corresponding;
+        Assert.Equal("x", switchOp.Value.Syntax.ToString());
+    }
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledContinue_OuterForEach_SkipsInnerFor()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: foreach (var x in new[] { 1 })
+                    {
+                        for (int i = 0; i < 10; i++)
+                        {
+                            /*<bind>*/continue outer;/*</bind>*/
+                        }
+                    }
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<ContinueStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<IForEachLoopOperation>(corresponding);
+    }
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledBreak_OuterDoWhile_SkipsInnerForEach()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: do
+                    {
+                        foreach (var x in new[] { 1 })
+                        {
+                            /*<bind>*/break outer;/*</bind>*/
+                        }
+                    } while (true);
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<BreakStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<IWhileLoopOperation>(corresponding);
+    }
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledBreak_SkipsTwoLevels()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: while (true)
+                    {
+                        for (int i = 0; i < 10; i++)
+                        {
+                            foreach (var x in new[] { 1 })
+                            {
+                                /*<bind>*/break outer;/*</bind>*/
+                            }
+                        }
+                    }
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<BreakStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<IWhileLoopOperation>(corresponding);
+    }
+
+    [Fact]
+    public void GetCorrespondingOperation_LabeledContinue_SkipsSwitchAndInnerLoop()
+    {
+        var source = """
+            class C
+            {
+                void F(int x)
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        switch (x)
+                        {
+                            case 0:
+                                while (true)
+                                {
+                                    /*<bind>*/continue outer;/*</bind>*/
+                                }
+                                break;
+                        }
+                    }
+                }
+            }
+            """;
+        var corresponding = GetCorrespondingOperation<ContinueStatementSyntax>(source);
+        Assert.NotNull(corresponding);
+        Assert.IsAssignableFrom<IForLoopOperation>(corresponding);
+    }
+
+    #endregion
+
+    #region IBranchOperation properties
+
+    [Fact]
+    public void IBranchOperation_LabeledBreak_HasBreakKind()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: while (true)
+                    {
+                        break outer;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var breakSyntax = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single();
+        var operation = model.GetOperation(breakSyntax) as IBranchOperation;
+
+        Assert.NotNull(operation);
+        Assert.Equal(BranchKind.Break, operation.BranchKind);
+        Assert.NotNull(operation.Target);
+    }
+
+    [Fact]
+    public void IBranchOperation_LabeledContinue_HasContinueKind()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: while (true)
+                    {
+                        continue outer;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var continueSyntax = tree.GetRoot().DescendantNodes().OfType<ContinueStatementSyntax>().Single();
+        var operation = model.GetOperation(continueSyntax) as IBranchOperation;
+
+        Assert.NotNull(operation);
+        Assert.Equal(BranchKind.Continue, operation.BranchKind);
+        Assert.NotNull(operation.Target);
+    }
+
+    [Fact]
+    public void IBranchOperation_LabeledBreak_NestedLoop_TargetDiffersFromUnlabeled()
+    {
+        var source = """
+            class C
+            {
+                void F()
+                {
+                    outer: while (true)
+                    {
+                        while (true)
+                        {
+                            break outer;
+                            break;
+                        }
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        comp.VerifyDiagnostics(
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(10, 17));
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var breakStmts = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().ToArray();
+        Assert.Equal(2, breakStmts.Length);
+
+        var labeledBreak = model.GetOperation(breakStmts[0]) as IBranchOperation;
+        var unlabeledBreak = model.GetOperation(breakStmts[1]) as IBranchOperation;
+
+        Assert.NotNull(labeledBreak);
+        Assert.NotNull(unlabeledBreak);
+        Assert.Equal(BranchKind.Break, labeledBreak.BranchKind);
+        Assert.Equal(BranchKind.Break, unlabeledBreak.BranchKind);
+        Assert.NotEqual(labeledBreak.Target, unlabeledBreak.Target);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private IOperation GetCorrespondingOperation<TSyntax>(string source) where TSyntax : SyntaxNode
+    {
+        var compilation = CreateCompilation(source);
+        var inner = GetOperationAndSyntaxForTest<TSyntax>(compilation).operation as IBranchOperation;
+        return inner?.GetCorrespondingOperation();
+    }
+
+    #endregion
+}

--- a/src/Compilers/CSharp/Test/CSharp15/LabeledBreakContinueSemanticModelTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/LabeledBreakContinueSemanticModelTests.cs
@@ -1,0 +1,545 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics;
+
+public sealed class LabeledBreakContinueSemanticModelTests : CSharpTestBase
+{
+    #region GetSymbolInfo
+
+    [Fact]
+    public void GetSymbolInfo_Break_ResolvesToLabelSymbol()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        break outer;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var labelDecl = tree.GetRoot().DescendantNodes().OfType<LabeledStatementSyntax>().Single();
+        var declaredSymbol = model.GetDeclaredSymbol(labelDecl);
+        Assert.NotNull(declaredSymbol);
+        Assert.Equal("outer", declaredSymbol.Name);
+        Assert.Equal(SymbolKind.Label, declaredSymbol.Kind);
+
+        var breakStmt = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single();
+        var labelRef = breakStmt.Name;
+        Assert.NotNull(labelRef);
+
+        var symbolInfo = model.GetSymbolInfo(labelRef);
+        Assert.Same(declaredSymbol, symbolInfo.Symbol);
+    }
+
+    [Fact]
+    public void GetSymbolInfo_Continue_ResolvesToLabelSymbol()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        continue outer;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var labelDecl = tree.GetRoot().DescendantNodes().OfType<LabeledStatementSyntax>().Single();
+        var declaredSymbol = model.GetDeclaredSymbol(labelDecl);
+
+        var continueStmt = tree.GetRoot().DescendantNodes().OfType<ContinueStatementSyntax>().Single();
+        var labelRef = continueStmt.Name;
+        Assert.NotNull(labelRef);
+
+        var symbolInfo = model.GetSymbolInfo(labelRef);
+        Assert.Same(declaredSymbol, symbolInfo.Symbol);
+    }
+
+    [Fact]
+    public void GetSymbolInfo_Break_NestedLoop_ResolvesToOuterLabel()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        inner: while (true)
+                        {
+                            break outer;
+                        }
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var labels = tree.GetRoot().DescendantNodes().OfType<LabeledStatementSyntax>().ToArray();
+        var outerLabel = model.GetDeclaredSymbol(labels.Single(l => l.Identifier.ValueText == "outer"));
+
+        var breakStmt = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single();
+        var symbolInfo = model.GetSymbolInfo(breakStmt.Name);
+        Assert.Same(outerLabel, symbolInfo.Symbol);
+    }
+
+    [Fact]
+    public void GetSymbolInfo_UnlabeledBreak_NoName()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    while (true)
+                    {
+                        break;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+
+        var breakStmt = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single();
+        Assert.Null(breakStmt.Name);
+    }
+
+    #endregion
+
+    #region GetTypeInfo / GetConversion / GetMemberGroup / GetConstantValue / GetAliasInfo
+
+    [Fact]
+    public void GetTypeInfo_OnLabel_ReturnsNothing()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        break outer;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var breakStmt = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single();
+        var typeInfo = model.GetTypeInfo(breakStmt.Name);
+        Assert.Null(typeInfo.Type);
+        Assert.Null(typeInfo.ConvertedType);
+    }
+
+    [Fact]
+    public void GetConversion_OnLabel_ReturnsNoConversion()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        break outer;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var breakStmt = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single();
+        var conversion = model.GetConversion(breakStmt.Name);
+        Assert.True(conversion.IsIdentity);
+    }
+
+    [Fact]
+    public void GetMemberGroup_OnLabel_ReturnsEmpty()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        break outer;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var breakStmt = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single();
+        var memberGroup = model.GetMemberGroup(breakStmt.Name);
+        Assert.Empty(memberGroup);
+    }
+
+    [Fact]
+    public void GetConstantValue_OnLabel_ReturnsNothing()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        break outer;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var breakStmt = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single();
+        var constantValue = model.GetConstantValue(breakStmt.Name);
+        Assert.False(constantValue.HasValue);
+    }
+
+    [Fact]
+    public void GetAliasInfo_OnLabel_ReturnsNull()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        break outer;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var breakStmt = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single();
+        var aliasInfo = model.GetAliasInfo(breakStmt.Name);
+        Assert.Null(aliasInfo);
+    }
+
+    #endregion
+
+    #region GetDeclaredSymbol
+
+    [Fact]
+    public void GetDeclaredSymbol_OnBreakStatement_ReturnsNull()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        break outer;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var breakStmt = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single();
+        Assert.Null(model.GetDeclaredSymbol(breakStmt));
+    }
+
+    [Fact]
+    public void GetDeclaredSymbol_OnContinueStatement_ReturnsNull()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        continue outer;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var continueStmt = tree.GetRoot().DescendantNodes().OfType<ContinueStatementSyntax>().Single();
+        Assert.Null(model.GetDeclaredSymbol(continueStmt));
+    }
+
+    [Fact]
+    public void GetDeclaredSymbol_OnLabeledStatement_ReturnsLabelSymbol()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        break outer;
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var labelDecl = tree.GetRoot().DescendantNodes().OfType<LabeledStatementSyntax>().Single();
+        var symbol = model.GetDeclaredSymbol(labelDecl);
+        Assert.NotNull(symbol);
+        Assert.Equal("outer", symbol.Name);
+        Assert.Equal(SymbolKind.Label, symbol.Kind);
+    }
+
+    #endregion
+
+    #region AnalyzeControlFlow
+
+    [Fact]
+    public void ControlFlow_LabeledBreak_IsExitPoint_WhenTargetOutsideRegion()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        while (true)
+                        {
+                            /*<bind>*/break outer;/*</bind>*/
+                        }
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var breakStmt = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single();
+        var controlFlow = model.AnalyzeControlFlow(breakStmt);
+
+        Assert.True(controlFlow.Succeeded);
+        Assert.Single(controlFlow.ExitPoints);
+        Assert.IsType<BreakStatementSyntax>(controlFlow.ExitPoints.Single());
+        Assert.True(controlFlow.StartPointIsReachable);
+        Assert.False(controlFlow.EndPointIsReachable);
+    }
+
+    [Fact]
+    public void ControlFlow_LabeledContinue_IsExitPoint_WhenTargetOutsideRegion()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        while (true)
+                        {
+                            /*<bind>*/continue outer;/*</bind>*/
+                        }
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var continueStmt = tree.GetRoot().DescendantNodes().OfType<ContinueStatementSyntax>().Single();
+        var controlFlow = model.AnalyzeControlFlow(continueStmt);
+
+        Assert.True(controlFlow.Succeeded);
+        Assert.Single(controlFlow.ExitPoints);
+        Assert.IsType<ContinueStatementSyntax>(controlFlow.ExitPoints.Single());
+        Assert.True(controlFlow.StartPointIsReachable);
+        Assert.False(controlFlow.EndPointIsReachable);
+    }
+
+    [Fact]
+    public void ControlFlow_LabeledBreak_NotExitPoint_WhenTargetInsideRegion()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    /*<bind>*/outer: while (true)
+                    {
+                        break outer;
+                    }/*</bind>*/
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var labelStmt = tree.GetRoot().DescendantNodes().OfType<LabeledStatementSyntax>().Single();
+        var controlFlow = model.AnalyzeControlFlow(labelStmt);
+
+        Assert.True(controlFlow.Succeeded);
+        Assert.Empty(controlFlow.ExitPoints);
+    }
+
+    [Fact]
+    public void ControlFlow_UnlabeledBreak_IsExitPoint_FromInnerLoop()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        /*<bind>*/break;/*</bind>*/
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var breakStmt = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single();
+        var controlFlow = model.AnalyzeControlFlow(breakStmt);
+
+        Assert.True(controlFlow.Succeeded);
+        Assert.Single(controlFlow.ExitPoints);
+    }
+
+    #endregion
+
+    #region AnalyzeDataFlow
+
+    [Fact]
+    public void DataFlow_LabeledBreak_VariableFlowsIn()
+    {
+        var source = """
+            class C
+            {
+                void M(bool b)
+                {
+                    int x = 0;
+                    outer: while (true)
+                    {
+                        while (true)
+                        {
+                            /*<bind>*/
+                            x++;
+                            if (b) break outer;
+                            /*</bind>*/
+                        }
+                    }
+                    System.Console.Write(x);
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var text = tree.GetText().ToString();
+        int start = text.IndexOf("/*<bind>*/") + "/*<bind>*/".Length;
+        int end = text.IndexOf("/*</bind>*/");
+
+        var stmts = tree.GetRoot().DescendantNodes().OfType<StatementSyntax>()
+            .Where(s => s.SpanStart >= start && s.Span.End <= end && s.Parent is BlockSyntax)
+            .ToArray();
+
+        var dataFlow = model.AnalyzeDataFlow(stmts.First(), stmts.Last());
+
+        Assert.True(dataFlow.Succeeded);
+        Assert.Contains(dataFlow.DataFlowsIn, s => s.Name == "x");
+        Assert.Contains(dataFlow.DataFlowsOut, s => s.Name == "x");
+        Assert.Contains(dataFlow.ReadInside, s => s.Name == "x");
+        Assert.Contains(dataFlow.WrittenInside, s => s.Name == "x");
+    }
+
+    [Fact]
+    public void DataFlow_LabeledContinue_VariableFlowsIn()
+    {
+        var source = """
+            class C
+            {
+                void M(bool b)
+                {
+                    int x = 0;
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        for (int j = 0; j < 10; j++)
+                        {
+                            /*<bind>*/
+                            x++;
+                            if (b) continue outer;
+                            /*</bind>*/
+                        }
+                    }
+                    System.Console.Write(x);
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+
+        var text = tree.GetText().ToString();
+        int start = text.IndexOf("/*<bind>*/") + "/*<bind>*/".Length;
+        int end = text.IndexOf("/*</bind>*/");
+
+        var stmts = tree.GetRoot().DescendantNodes().OfType<StatementSyntax>()
+            .Where(s => s.SpanStart >= start && s.Span.End <= end && s.Parent is BlockSyntax)
+            .ToArray();
+
+        var dataFlow = model.AnalyzeDataFlow(stmts.First(), stmts.Last());
+
+        Assert.True(dataFlow.Succeeded);
+        Assert.Contains(dataFlow.DataFlowsIn, s => s.Name == "x");
+        Assert.Contains(dataFlow.DataFlowsOut, s => s.Name == "x");
+    }
+
+    #endregion
+}

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LabeledBreakContinueBindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LabeledBreakContinueBindingTests.cs
@@ -1,0 +1,1267 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests;
+
+public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
+{
+    private static readonly CSharpParseOptions s_optionsCSharp14 =
+        TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp14);
+
+    private static readonly CSharpParseOptions s_optionsCSharp13 =
+        TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp13);
+
+    #region Valid: all loop types
+
+    [Fact]
+    public void Break_LabeledWhile()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        while (true)
+                            break outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Continue_LabeledWhile()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        while (true)
+                            continue outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Break_LabeledDoWhile()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: do
+                    {
+                        do break outer; while (true);
+                    } while (true);
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: do
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Continue_LabeledDoWhile()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: do
+                    {
+                        while (true)
+                            continue outer;
+                    } while (false);
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: do
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Break_LabeledFor()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        for (int j = 0; j < 10; j++)
+                            break outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: for (int i = 0; i < 10; i++)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
+            // (7,37): warning CS0162: Unreachable code detected
+            //             for (int j = 0; j < 10; j++)
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(7, 37));
+    }
+
+    [Fact]
+    public void Continue_LabeledFor()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        for (int j = 0; j < 10; j++)
+                            continue outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: for (int i = 0; i < 10; i++)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
+            // (7,37): warning CS0162: Unreachable code detected
+            //             for (int j = 0; j < 10; j++)
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(7, 37));
+    }
+
+    [Fact]
+    public void Break_LabeledForEach()
+    {
+        var source = """
+            class C
+            {
+                void M(string[] args)
+                {
+                    outer: foreach (var a in args)
+                    {
+                        foreach (var b in args)
+                            break outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: foreach (var a in args)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Continue_LabeledForEach()
+    {
+        var source = """
+            class C
+            {
+                void M(string[] args)
+                {
+                    outer: foreach (var a in args)
+                    {
+                        foreach (var b in args)
+                            continue outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: foreach (var a in args)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Continue_LabeledForEachDeconstruction()
+    {
+        var source = """
+            class C
+            {
+                void M((int, int)[] items)
+                {
+                    outer: foreach (var (x, y) in items)
+                    {
+                        foreach (var z in items)
+                            continue outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: foreach (var (x, y) in items)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    #endregion
+
+    #region Valid: switch
+
+    [Fact]
+    public void Break_LabeledSwitch()
+    {
+        var source = """
+            class C
+            {
+                void M(int x)
+                {
+                    outer: switch (x)
+                    {
+                        default:
+                            while (true)
+                                break outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: switch (x)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Break_LabelOnLoop_FromInsideSwitch()
+    {
+        var source = """
+            class C
+            {
+                void M(int x)
+                {
+                    outer: while (true)
+                    {
+                        switch (x)
+                        {
+                            default:
+                                break outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Break_NestedSwitches_BreakOuter()
+    {
+        var source = """
+            class C
+            {
+                void M(int x)
+                {
+                    outer: switch (x)
+                    {
+                        case 0:
+                            switch (x)
+                            {
+                                case 0: break outer;
+                            }
+                            break;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: switch (x)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    #endregion
+
+    #region Valid: nested labels
+
+    [Fact]
+    public void Break_StackedLabels()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    a: b: c: while (true)
+                    {
+                        break b;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         a: b: c: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "a").WithLocation(5, 9),
+            // (5,12): warning CS0164: This label has not been referenced
+            //         a: b: c: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "b").WithLocation(5, 12),
+            // (5,15): warning CS0164: This label has not been referenced
+            //         a: b: c: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "c").WithLocation(5, 15));
+    }
+
+    [Fact]
+    public void Break_DeeplyNested_LoopSwitchLoop()
+    {
+        var source = """
+            class C
+            {
+                void M(int a, int b)
+                {
+                    L0: while (a-- > 0)
+                    {
+                        L1: switch (b)
+                        {
+                            default:
+                                L2: while (true)
+                                {
+                                    if (a == 0) break L0;
+                                    if (b == 0) break L1;
+                                    continue L2;
+                                }
+                                break;
+                        }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         L0: while (a-- > 0)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L0").WithLocation(5, 9),
+            // (7,13): warning CS0164: This label has not been referenced
+            //             L1: switch (b)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L1").WithLocation(7, 13),
+            // (10,21): warning CS0164: This label has not been referenced
+            //                     L2: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L2").WithLocation(10, 21),
+            // (16,21): warning CS0162: Unreachable code detected
+            //                     break;
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(16, 21));
+    }
+
+    #endregion
+
+    #region Valid: interaction with other constructs
+
+    [Fact]
+    public void Break_InsideTryCatch()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        try
+                        {
+                            break outer;
+                        }
+                        catch { }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Break_InsideChecked()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        checked
+                        {
+                            break outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: for (int i = 0; i < 10; i++)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
+            // (5,40): warning CS0162: Unreachable code detected
+            //         outer: for (int i = 0; i < 10; i++)
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "i").WithLocation(5, 40));
+    }
+
+    [Fact]
+    public void Break_InsideLockUsing()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        lock (this)
+                        {
+                            using var d = default(System.IDisposable);
+                            break outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Break_PatternSwitchWithWhen()
+    {
+        var source = """
+            class C
+            {
+                void M(object o)
+                {
+                    outer: while (true)
+                    {
+                        switch (o)
+                        {
+                            case int x when x > 0:
+                                break outer;
+                            default:
+                                break;
+                        }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Continue_AsyncMethod()
+    {
+        var source = """
+            using System.Threading.Tasks;
+            class C
+            {
+                async Task M()
+                {
+                    outer: for (int i = 0; i < 1; i++)
+                    {
+                        for (int j = 0; j < 1; j++)
+                        {
+                            await Task.Yield();
+                            continue outer;
+                        }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (6,9): warning CS0164: This label has not been referenced
+            //         outer: for (int i = 0; i < 1; i++)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(6, 9),
+            // (8,36): warning CS0162: Unreachable code detected
+            //             for (int j = 0; j < 1; j++)
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(8, 36));
+    }
+
+    [Fact]
+    public void Break_Iterator()
+    {
+        var source = """
+            using System.Collections.Generic;
+            class C
+            {
+                IEnumerable<int> M()
+                {
+                    outer: while (true)
+                    {
+                        yield return 1;
+                        break outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (6,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(6, 9));
+    }
+
+    [Fact]
+    public void Break_GotoAndLabeledBreak_SameLabel()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    L: while (true)
+                    {
+                        goto L;
+                        break L;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (8,13): warning CS0162: Unreachable code detected
+            //             break L;
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(8, 13));
+    }
+
+    [Fact]
+    public void Continue_SwitchInsideLabeledFor()
+    {
+        var source = """
+            class C
+            {
+                void M(int x)
+                {
+                    L: for (;;)
+                        switch (x)
+                        {
+                            default: continue L;
+                        }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         L: for (;;)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9));
+    }
+
+    [Fact]
+    public void Break_UnicodeEscapedLabel()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    \u006Futer: while (true)
+                    {
+                        break outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         \u006Futer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, @"\u006Futer").WithLocation(5, 9));
+    }
+
+    #endregion
+
+    #region Invalid: label not found
+
+    [Fact]
+    public void Break_LabelNotFound()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    while (true)
+                        break missing;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (6,19): error CS0159: No such label 'missing' within the scope of the goto statement
+            //             break missing;
+            Diagnostic(ErrorCode.ERR_LabelNotFound, "missing").WithArguments("missing").WithLocation(6, 19));
+    }
+
+    [Fact]
+    public void Break_LabelInSiblingBlock()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    { L: while (true) { } }
+                    { break L; }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,11): warning CS0164: This label has not been referenced
+            //         { L: while (true) { } }
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 11),
+            // (6,11): warning CS0162: Unreachable code detected
+            //         { break L; }
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(6, 11),
+            // (6,17): error CS0159: No such label 'L' within the scope of the goto statement
+            //         { break L; }
+            Diagnostic(ErrorCode.ERR_LabelNotFound, "L").WithArguments("L").WithLocation(6, 17));
+    }
+
+    #endregion
+
+    #region Invalid: label not on loop/switch
+
+    [Fact]
+    public void Break_LabelOnBlock()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    L: { break L; }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         L: { break L; }
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
+            // (5,20): error CS9378: The label 'L' does not refer to a containing loop or switch statement
+            //         L: { break L; }
+            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch, "L").WithArguments("L").WithLocation(5, 20));
+    }
+
+    [Fact]
+    public void Break_LabelOnIf()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    L: if (true)
+                        break L;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         L: if (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
+            // (6,19): error CS9378: The label 'L' does not refer to a containing loop or switch statement
+            //             break L;
+            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch, "L").WithArguments("L").WithLocation(6, 19));
+    }
+
+    [Fact]
+    public void Break_LabelOnEmptyStatement()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    L: ;
+                    while (true) break L;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         L: ;
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
+            // (6,28): error CS9378: The label 'L' does not refer to a containing loop or switch statement
+            //         while (true) break L;
+            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch, "L").WithArguments("L").WithLocation(6, 28));
+    }
+
+    [Fact]
+    public void Break_LabelOnExpressionStatement()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    L: System.Console.WriteLine();
+                    if (true) break L;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         L: System.Console.WriteLine();
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
+            // (6,25): error CS9378: The label 'L' does not refer to a containing loop or switch statement
+            //         if (true) break L;
+            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch, "L").WithArguments("L").WithLocation(6, 25));
+    }
+
+    [Fact]
+    public void Break_LabelOnLocalDeclaration_SwitchExpression()
+    {
+        var source = """
+            class C
+            {
+                void M(int x)
+                {
+                    L: var y = x switch { _ => 1 };
+                    while (true) break L;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         L: var y = x switch { _ => 1 };
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
+            // (6,28): error CS9378: The label 'L' does not refer to a containing loop or switch statement
+            //         while (true) break L;
+            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch, "L").WithArguments("L").WithLocation(6, 28));
+    }
+
+    [Fact]
+    public void Break_LabelOnLock()
+    {
+        var source = """
+            class C
+            {
+                void M(object o)
+                {
+                    L: lock (o) { break L; }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         L: lock (o) { break L; }
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
+            // (5,29): error CS9378: The label 'L' does not refer to a containing loop or switch statement
+            //         L: lock (o) { break L; }
+            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch, "L").WithArguments("L").WithLocation(5, 29));
+    }
+
+    #endregion
+
+    #region Invalid: continue targeting switch
+
+    [Fact]
+    public void Continue_TargetIsSwitch()
+    {
+        var source = """
+            class C
+            {
+                void M(int x)
+                {
+                    outer: switch (x)
+                    {
+                        default: continue outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: switch (x)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
+            // (7,13): error CS8070: Control cannot fall out of switch from final case label ('default:')
+            //             default: continue outer;
+            Diagnostic(ErrorCode.ERR_SwitchFallOut, "default:").WithArguments("default:").WithLocation(7, 13),
+            // (7,31): error CS9379: The label 'outer' does not refer to a containing loop statement
+            //             default: continue outer;
+            Diagnostic(ErrorCode.ERR_LabeledContinueNotOnLoop, "outer").WithArguments("outer").WithLocation(7, 31));
+    }
+
+    #endregion
+
+    #region Invalid: label not containing
+
+    [Fact]
+    public void Break_LabelOnSiblingLoop()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (false) { }
+                    while (true) { break outer; }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: while (false) { }
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
+            // (6,30): error CS9380: The label 'outer' does not refer to a statement that contains this break or continue statement
+            //         while (true) { break outer; }
+            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotContaining, "outer").WithArguments("outer").WithLocation(6, 30));
+    }
+
+    [Fact]
+    public void Continue_LabelOnFollowingLoop()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    while (true) { continue outer; }
+                    outer: while (false) { }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,33): error CS9380: The label 'outer' does not refer to a statement that contains this break or continue statement
+            //         while (true) { continue outer; }
+            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotContaining, "outer").WithArguments("outer").WithLocation(5, 33),
+            // (6,9): warning CS0162: Unreachable code detected
+            //         outer: while (false) { }
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "outer").WithLocation(6, 9),
+            // (6,9): warning CS0164: This label has not been referenced
+            //         outer: while (false) { }
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(6, 9));
+    }
+
+    [Fact]
+    public void Break_LabelAfterBreak()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    foreach (var x in new int[0])
+                    {
+                        break outer;
+                    outer: foreach (var y in new int[0]) { }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (7,19): error CS9380: The label 'outer' does not refer to a statement that contains this break or continue statement
+            //             break outer;
+            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotContaining, "outer").WithArguments("outer").WithLocation(7, 19),
+            // (8,9): warning CS0164: This label has not been referenced
+            //         outer: foreach (var y in new int[0]) { }
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(8, 9));
+    }
+
+    [Fact]
+    public void Continue_LabelOnInnerLoop_NotContaining()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    foreach (var x in new int[0])
+                    {
+                        continue outer;
+                    outer: foreach (var y in new int[0]) { }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (7,22): error CS9380: The label 'outer' does not refer to a statement that contains this break or continue statement
+            //             continue outer;
+            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotContaining, "outer").WithArguments("outer").WithLocation(7, 22),
+            // (8,9): warning CS0164: This label has not been referenced
+            //         outer: foreach (var y in new int[0]) { }
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(8, 9));
+    }
+
+    [Fact]
+    public void Break_LabelOnDeeperNestedLoop()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    foreach (var x in new int[0])
+                    {
+                        continue outer;
+                        { outer: foreach (var y in new int[0]) { } }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (7,22): error CS0159: No such label 'outer' within the scope of the goto statement
+            //             continue outer;
+            Diagnostic(ErrorCode.ERR_LabelNotFound, "outer").WithArguments("outer").WithLocation(7, 22),
+            // (8,15): warning CS0164: This label has not been referenced
+            //             { outer: foreach (var y in new int[0]) { } }
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(8, 15));
+    }
+
+    #endregion
+
+    #region Invalid: label various illegal positions
+
+    [Fact]
+    public void Continue_LabelExistsAfterLoop()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    foreach (var x in new int[0])
+                    {
+                        continue outer;
+                    }
+                    outer: ;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (7,22): error CS9379: The label 'outer' does not refer to a containing loop statement
+            //             continue outer;
+            Diagnostic(ErrorCode.ERR_LabeledContinueNotOnLoop, "outer").WithArguments("outer").WithLocation(7, 22),
+            // (9,9): warning CS0164: This label has not been referenced
+            //         outer: ;
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(9, 9));
+    }
+
+    [Fact]
+    public void Continue_LabelBeforeLoop()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: ;
+                    foreach (var x in new int[0])
+                    {
+                        continue outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: ;
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
+            // (8,22): error CS9379: The label 'outer' does not refer to a containing loop statement
+            //             continue outer;
+            Diagnostic(ErrorCode.ERR_LabeledContinueNotOnLoop, "outer").WithArguments("outer").WithLocation(8, 22));
+    }
+
+    [Fact]
+    public void Break_LabelOnContainingForEach_InsideNestedBlock()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    foreach (var x in new int[0])
+                    {
+                        continue outer;
+                        { outer: foreach (var y in new int[0]) { } }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (7,22): error CS0159: No such label 'outer' within the scope of the goto statement
+            //             continue outer;
+            Diagnostic(ErrorCode.ERR_LabelNotFound, "outer").WithArguments("outer").WithLocation(7, 22),
+            // (8,15): warning CS0164: This label has not been referenced
+            //             { outer: foreach (var y in new int[0]) { } }
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(8, 15));
+    }
+
+    #endregion
+
+    #region Lambda and local function boundaries
+
+    [Fact]
+    public void Break_InsideLambda_LabelOutside()
+    {
+        var source = """
+            using System;
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        Action a = () => { break outer; };
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (6,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(6, 9),
+            // (8,32): error CS1632: Control cannot leave the body of an anonymous method or lambda expression
+            //             Action a = () => { break outer; };
+            Diagnostic(ErrorCode.ERR_BadDelegateLeave, "break").WithLocation(8, 32));
+    }
+
+    [Fact]
+    public void Break_InsideLocalFunction_LabelOutside()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        void F() { break outer; }
+                        F();
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
+            // (7,24): error CS1632: Control cannot leave the body of an anonymous method or lambda expression
+            //             void F() { break outer; }
+            Diagnostic(ErrorCode.ERR_BadDelegateLeave, "break").WithLocation(7, 24));
+    }
+
+    [Fact]
+    public void Break_LabelInsideLambda_BreakOutside()
+    {
+        var source = """
+            using System;
+            class C
+            {
+                void M()
+                {
+                    Action a = () => { outer: while (true) { } };
+                    break outer;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (6,28): warning CS0164: This label has not been referenced
+            //         Action a = () => { outer: while (true) { } };
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(6, 28),
+            // (7,15): error CS0159: No such label 'outer' within the scope of the goto statement
+            //         break outer;
+            Diagnostic(ErrorCode.ERR_LabelNotFound, "outer").WithArguments("outer").WithLocation(7, 15));
+    }
+
+    #endregion
+
+    #region Finally blocks
+
+    [Fact]
+    public void Break_InFinally_TargetsOuterLoop()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        try { }
+                        finally { break outer; }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: for (int i = 0; i < 10; i++)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
+            // (5,40): warning CS0162: Unreachable code detected
+            //         outer: for (int i = 0; i < 10; i++)
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "i").WithLocation(5, 40),
+            // (8,23): error CS0157: Control cannot leave the body of a finally clause
+            //             finally { break outer; }
+            Diagnostic(ErrorCode.ERR_BadFinallyLeave, "break").WithLocation(8, 23));
+    }
+
+    [Fact]
+    public void Continue_InFinally_TargetsOuterLoop()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        try { }
+                        finally { continue outer; }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: for (int i = 0; i < 10; i++)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
+            // (8,23): error CS0157: Control cannot leave the body of a finally clause
+            //             finally { continue outer; }
+            Diagnostic(ErrorCode.ERR_BadFinallyLeave, "continue").WithLocation(8, 23));
+    }
+
+    [Fact]
+    public void Break_InTryWithFinally_Valid()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        try { break outer; }
+                        finally { }
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    #endregion
+
+    #region Language version gating
+
+    [Fact]
+    public void Break_CSharp13_FeatureNotAvailable()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                        break outer;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp13).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
+            // (6,19): error CS9260: Feature 'labeled break and continue' is not available in C# 13.0. Please use language version 14.0 or greater.
+            //             break outer;
+            Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion13, "outer").WithArguments("labeled break and continue", "14.0").WithLocation(6, 19));
+    }
+
+    [Fact]
+    public void Continue_CSharp13_FeatureNotAvailable()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        for (int j = 0; j < 10; j++)
+                            continue outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp13).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: for (int i = 0; i < 10; i++)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
+            // (7,37): warning CS0162: Unreachable code detected
+            //             for (int j = 0; j < 10; j++)
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(7, 37),
+            // (8,26): error CS9260: Feature 'labeled break and continue' is not available in C# 13.0. Please use language version 14.0 or greater.
+            //                 continue outer;
+            Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion13, "outer").WithArguments("labeled break and continue", "14.0").WithLocation(8, 26));
+    }
+
+    [Fact]
+    public void Break_Preview_Works()
+    {
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                        break outer;
+                }
+            }
+            """;
+        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
+            // (5,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+    }
+
+    #endregion
+
+    #region Top-level statements
+
+    [Fact]
+    public void Break_TopLevelStatements()
+    {
+        var source = """
+            outer: for (int i = 0; i < 1; i++)
+                break outer;
+            """;
+        CreateCompilation(source, parseOptions: s_optionsCSharp14, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+            // (1,1): warning CS0164: This label has not been referenced
+            // outer: for (int i = 0; i < 1; i++)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(1, 1),
+            // (1,31): warning CS0162: Unreachable code detected
+            // outer: for (int i = 0; i < 1; i++)
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "i").WithLocation(1, 31));
+    }
+
+    #endregion
+}

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LabeledBreakContinueBindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LabeledBreakContinueBindingTests.cs
@@ -14,9 +14,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
     private static readonly CSharpParseOptions s_optionsCSharp14 =
         TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp14);
 
-    private static readonly CSharpParseOptions s_optionsCSharp13 =
-        TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp13);
-
     #region Valid: all loop types
 
     [Fact]
@@ -35,7 +32,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -57,7 +54,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -78,7 +75,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: do
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -100,7 +97,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: do
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -122,7 +119,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: for (int i = 0; i < 10; i++)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
@@ -147,7 +144,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: for (int i = 0; i < 10; i++)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
@@ -172,7 +169,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: foreach (var a in args)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -194,7 +191,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: foreach (var a in args)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -216,7 +213,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: foreach (var (x, y) in items)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -243,7 +240,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: switch (x)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -268,7 +265,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -294,7 +291,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: switch (x)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -319,7 +316,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         a: b: c: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "a").WithLocation(5, 9),
@@ -328,7 +325,10 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "b").WithLocation(5, 12),
             // (5,15): warning CS0164: This label has not been referenced
             //         a: b: c: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "c").WithLocation(5, 15));
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "c").WithLocation(5, 15),
+            // (7,19): error CS9378: No enclosing loop or switch statement with the label 'b' out of which to break or continue
+            //             break b;
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "b").WithArguments("b").WithLocation(7, 19));
     }
 
     [Fact]
@@ -356,7 +356,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         L0: while (a-- > 0)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L0").WithLocation(5, 9),
@@ -394,7 +394,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -418,7 +418,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: for (int i = 0; i < 10; i++)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
@@ -446,7 +446,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -473,7 +473,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -499,7 +499,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (6,9): warning CS0164: This label has not been referenced
             //         outer: for (int i = 0; i < 1; i++)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(6, 9),
@@ -525,7 +525,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (6,9): warning CS0164: This label has not been referenced
             //         outer: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(6, 9));
@@ -547,7 +547,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (8,13): warning CS0162: Unreachable code detected
             //             break L;
             Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(8, 13));
@@ -569,7 +569,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         L: for (;;)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9));
@@ -590,7 +590,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         \u006Futer: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, @"\u006Futer").WithLocation(5, 9));
@@ -613,10 +613,10 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (6,19): error CS0159: No such label 'missing' within the scope of the goto statement
             //             break missing;
-            Diagnostic(ErrorCode.ERR_LabelNotFound, "missing").WithArguments("missing").WithLocation(6, 19));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "missing").WithArguments("missing").WithLocation(6, 19));
     }
 
     [Fact]
@@ -632,7 +632,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,11): warning CS0164: This label has not been referenced
             //         { L: while (true) { } }
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 11),
@@ -641,7 +641,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             Diagnostic(ErrorCode.WRN_UnreachableCode, "break").WithLocation(6, 11),
             // (6,17): error CS0159: No such label 'L' within the scope of the goto statement
             //         { break L; }
-            Diagnostic(ErrorCode.ERR_LabelNotFound, "L").WithArguments("L").WithLocation(6, 17));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "L").WithArguments("L").WithLocation(6, 17));
     }
 
     #endregion
@@ -660,13 +660,13 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         L: { break L; }
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
             // (5,20): error CS9378: The label 'L' does not refer to a containing loop or switch statement
             //         L: { break L; }
-            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch, "L").WithArguments("L").WithLocation(5, 20));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "L").WithArguments("L").WithLocation(5, 20));
     }
 
     [Fact]
@@ -682,13 +682,13 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         L: if (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
             // (6,19): error CS9378: The label 'L' does not refer to a containing loop or switch statement
             //             break L;
-            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch, "L").WithArguments("L").WithLocation(6, 19));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "L").WithArguments("L").WithLocation(6, 19));
     }
 
     [Fact]
@@ -704,13 +704,13 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         L: ;
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
             // (6,28): error CS9378: The label 'L' does not refer to a containing loop or switch statement
             //         while (true) break L;
-            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch, "L").WithArguments("L").WithLocation(6, 28));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "L").WithArguments("L").WithLocation(6, 28));
     }
 
     [Fact]
@@ -726,13 +726,13 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         L: System.Console.WriteLine();
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
             // (6,25): error CS9378: The label 'L' does not refer to a containing loop or switch statement
             //         if (true) break L;
-            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch, "L").WithArguments("L").WithLocation(6, 25));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "L").WithArguments("L").WithLocation(6, 25));
     }
 
     [Fact]
@@ -748,13 +748,13 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         L: var y = x switch { _ => 1 };
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
             // (6,28): error CS9378: The label 'L' does not refer to a containing loop or switch statement
             //         while (true) break L;
-            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch, "L").WithArguments("L").WithLocation(6, 28));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "L").WithArguments("L").WithLocation(6, 28));
     }
 
     [Fact]
@@ -769,13 +769,13 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         L: lock (o) { break L; }
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
             // (5,29): error CS9378: The label 'L' does not refer to a containing loop or switch statement
             //         L: lock (o) { break L; }
-            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotOnLoopOrSwitch, "L").WithArguments("L").WithLocation(5, 29));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "L").WithArguments("L").WithLocation(5, 29));
     }
 
     #endregion
@@ -797,7 +797,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: switch (x)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
@@ -806,7 +806,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             Diagnostic(ErrorCode.ERR_SwitchFallOut, "default:").WithArguments("default:").WithLocation(7, 13),
             // (7,31): error CS9379: The label 'outer' does not refer to a containing loop statement
             //             default: continue outer;
-            Diagnostic(ErrorCode.ERR_LabeledContinueNotOnLoop, "outer").WithArguments("outer").WithLocation(7, 31));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "outer").WithArguments("outer").WithLocation(7, 31));
     }
 
     #endregion
@@ -826,13 +826,13 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: while (false) { }
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
             // (6,30): error CS9380: The label 'outer' does not refer to a statement that contains this break or continue statement
             //         while (true) { break outer; }
-            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotContaining, "outer").WithArguments("outer").WithLocation(6, 30));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "outer").WithArguments("outer").WithLocation(6, 30));
     }
 
     [Fact]
@@ -848,10 +848,10 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,33): error CS9380: The label 'outer' does not refer to a statement that contains this break or continue statement
             //         while (true) { continue outer; }
-            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotContaining, "outer").WithArguments("outer").WithLocation(5, 33),
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "outer").WithArguments("outer").WithLocation(5, 33),
             // (6,9): warning CS0162: Unreachable code detected
             //         outer: while (false) { }
             Diagnostic(ErrorCode.WRN_UnreachableCode, "outer").WithLocation(6, 9),
@@ -876,10 +876,10 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (7,19): error CS9380: The label 'outer' does not refer to a statement that contains this break or continue statement
             //             break outer;
-            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotContaining, "outer").WithArguments("outer").WithLocation(7, 19),
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "outer").WithArguments("outer").WithLocation(7, 19),
             // (8,9): warning CS0164: This label has not been referenced
             //         outer: foreach (var y in new int[0]) { }
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(8, 9));
@@ -901,10 +901,10 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (7,22): error CS9380: The label 'outer' does not refer to a statement that contains this break or continue statement
             //             continue outer;
-            Diagnostic(ErrorCode.ERR_LabeledBreakContinueNotContaining, "outer").WithArguments("outer").WithLocation(7, 22),
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "outer").WithArguments("outer").WithLocation(7, 22),
             // (8,9): warning CS0164: This label has not been referenced
             //         outer: foreach (var y in new int[0]) { }
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(8, 9));
@@ -926,10 +926,10 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (7,22): error CS0159: No such label 'outer' within the scope of the goto statement
             //             continue outer;
-            Diagnostic(ErrorCode.ERR_LabelNotFound, "outer").WithArguments("outer").WithLocation(7, 22),
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "outer").WithArguments("outer").WithLocation(7, 22),
             // (8,15): warning CS0164: This label has not been referenced
             //             { outer: foreach (var y in new int[0]) { } }
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(8, 15));
@@ -955,10 +955,10 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (7,22): error CS9379: The label 'outer' does not refer to a containing loop statement
             //             continue outer;
-            Diagnostic(ErrorCode.ERR_LabeledContinueNotOnLoop, "outer").WithArguments("outer").WithLocation(7, 22),
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "outer").WithArguments("outer").WithLocation(7, 22),
             // (9,9): warning CS0164: This label has not been referenced
             //         outer: ;
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(9, 9));
@@ -980,13 +980,13 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: ;
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
             // (8,22): error CS9379: The label 'outer' does not refer to a containing loop statement
             //             continue outer;
-            Diagnostic(ErrorCode.ERR_LabeledContinueNotOnLoop, "outer").WithArguments("outer").WithLocation(8, 22));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "outer").WithArguments("outer").WithLocation(8, 22));
     }
 
     [Fact]
@@ -1005,10 +1005,10 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (7,22): error CS0159: No such label 'outer' within the scope of the goto statement
             //             continue outer;
-            Diagnostic(ErrorCode.ERR_LabelNotFound, "outer").WithArguments("outer").WithLocation(7, 22),
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "outer").WithArguments("outer").WithLocation(7, 22),
             // (8,15): warning CS0164: This label has not been referenced
             //             { outer: foreach (var y in new int[0]) { } }
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(8, 15));
@@ -1034,7 +1034,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (6,9): warning CS0164: This label has not been referenced
             //         outer: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(6, 9),
@@ -1059,13 +1059,13 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
-            // (7,24): error CS1632: Control cannot leave the body of an anonymous method or lambda expression
+            // (7,30): error CS9378: No enclosing loop or switch statement with the label 'outer' out of which to break or continue
             //             void F() { break outer; }
-            Diagnostic(ErrorCode.ERR_BadDelegateLeave, "break").WithLocation(7, 24));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "outer").WithArguments("outer").WithLocation(7, 30));
     }
 
     [Fact]
@@ -1082,13 +1082,13 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (6,28): warning CS0164: This label has not been referenced
             //         Action a = () => { outer: while (true) { } };
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(6, 28),
             // (7,15): error CS0159: No such label 'outer' within the scope of the goto statement
             //         break outer;
-            Diagnostic(ErrorCode.ERR_LabelNotFound, "outer").WithArguments("outer").WithLocation(7, 15));
+            Diagnostic(ErrorCode.ERR_NoBreakOrContId, "outer").WithArguments("outer").WithLocation(7, 15));
     }
 
     #endregion
@@ -1111,7 +1111,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: for (int i = 0; i < 10; i++)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
@@ -1139,7 +1139,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: for (int i = 0; i < 10; i++)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
@@ -1164,7 +1164,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
+        CreateCompilation(source).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
@@ -1175,7 +1175,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
     #region Language version gating
 
     [Fact]
-    public void Break_CSharp13_FeatureNotAvailable()
+    public void Break_CSharp14_FeatureInPreview()
     {
         var source = """
             class C
@@ -1187,17 +1187,17 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp13).VerifyDiagnostics(
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
-            // (6,19): error CS9260: Feature 'labeled break and continue' is not available in C# 13.0. Please use language version 14.0 or greater.
+            // (6,19): error CS8652: The feature 'labeled break and continue' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //             break outer;
-            Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion13, "outer").WithArguments("labeled break and continue", "14.0").WithLocation(6, 19));
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "outer").WithArguments("labeled break and continue").WithLocation(6, 19));
     }
 
     [Fact]
-    public void Continue_CSharp13_FeatureNotAvailable()
+    public void Continue_CSharp14_FeatureInPreview()
     {
         var source = """
             class C
@@ -1212,35 +1212,16 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
                 }
             }
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp13).VerifyDiagnostics(
+        CreateCompilation(source, parseOptions: s_optionsCSharp14).VerifyDiagnostics(
             // (5,9): warning CS0164: This label has not been referenced
             //         outer: for (int i = 0; i < 10; i++)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
             // (7,37): warning CS0162: Unreachable code detected
             //             for (int j = 0; j < 10; j++)
             Diagnostic(ErrorCode.WRN_UnreachableCode, "j").WithLocation(7, 37),
-            // (8,26): error CS9260: Feature 'labeled break and continue' is not available in C# 13.0. Please use language version 14.0 or greater.
+            // (8,26): error CS8652: The feature 'labeled break and continue' is currently in Preview and *unsupported*. To use Preview features, use the 'preview' language version.
             //                 continue outer;
-            Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion13, "outer").WithArguments("labeled break and continue", "14.0").WithLocation(8, 26));
-    }
-
-    [Fact]
-    public void Break_Preview_Works()
-    {
-        var source = """
-            class C
-            {
-                void M()
-                {
-                    outer: while (true)
-                        break outer;
-                }
-            }
-            """;
-        CreateCompilation(source, parseOptions: TestOptions.RegularPreview).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9));
+            Diagnostic(ErrorCode.ERR_FeatureInPreview, "outer").WithArguments("labeled break and continue").WithLocation(8, 26));
     }
 
     #endregion
@@ -1254,7 +1235,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             outer: for (int i = 0; i < 1; i++)
                 break outer;
             """;
-        CreateCompilation(source, parseOptions: s_optionsCSharp14, options: TestOptions.ReleaseExe).VerifyDiagnostics(
+        CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
             // (1,1): warning CS0164: This label has not been referenced
             // outer: for (int i = 0; i < 1; i++)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(1, 1),


### PR DESCRIPTION
## Summary
- Binding: label resolution via binder chain, error diagnostics, feature gating.
- Refactor `LoopBinder`/`SwitchBinder` for `GetBreakLabel`/`GetContinueLabel(string?)`.
- Fix `WRN_UnreferencedLabel` suppression.
- Lowering/emit, IL verification, semantic model API tests, IOperation tests.

> Stack: **2/8** — Binding/Lowering/Emit/SemanticModel/IOperation