### PR TITLE
3/8: Offer enclosing labels in completion after break/continue

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -3819,6 +3819,195 @@ public sealed partial class SymbolCompletionProviderTests : AbstractCSharpComple
                     goto Goo $$
             """, "Goo");
 
+    [Fact]
+    public Task LabelAfterBreak_ImmediateWhile()
+        => VerifyItemExistsAsync("""
+            class C
+            {
+                void F()
+                {
+                    outer: while (true)
+                    {
+                        break $$
+                    }
+                }
+            }
+            """, "outer");
+
+    [Fact]
+    public Task LabelAfterContinue_ImmediateFor()
+        => VerifyItemExistsAsync("""
+            class C
+            {
+                void F()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        continue $$
+                    }
+                }
+            }
+            """, "outer");
+
+    [Fact]
+    public Task LabelAfterBreak_OuterWhile_SkipsInnerWhile()
+        => VerifyItemExistsAsync("""
+            class C
+            {
+                void F()
+                {
+                    outer: while (true)
+                    {
+                        while (true)
+                        {
+                            break $$
+                        }
+                    }
+                }
+            }
+            """, "outer");
+
+    [Fact]
+    public Task LabelAfterContinue_OuterFor_SkipsInnerWhile()
+        => VerifyItemExistsAsync("""
+            class C
+            {
+                void F()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        while (true)
+                        {
+                            continue $$
+                        }
+                    }
+                }
+            }
+            """, "outer");
+
+    [Fact]
+    public Task LabelAfterBreak_Switch()
+        => VerifyItemExistsAsync("""
+            class C
+            {
+                void F(int x)
+                {
+                    outer: switch (x)
+                    {
+                        case 0:
+                            break $$
+                    }
+                }
+            }
+            """, "outer");
+
+    [Fact]
+    public Task LabelAfterContinue_DoesNotOfferSwitchLabel()
+        => VerifyItemIsAbsentAsync("""
+            class C
+            {
+                void F(int x)
+                {
+                    outer: switch (x)
+                    {
+                        case 0:
+                            inner: while (true)
+                            {
+                                continue $$
+                            }
+                    }
+                }
+            }
+            """, "outer");
+
+    [Fact]
+    public Task LabelAfterContinue_OffersLoopLabelInsideSwitch()
+        => VerifyItemExistsAsync("""
+            class C
+            {
+                void F(int x)
+                {
+                    outer: switch (x)
+                    {
+                        case 0:
+                            inner: while (true)
+                            {
+                                continue $$
+                            }
+                    }
+                }
+            }
+            """, "inner");
+
+    [Fact]
+    public Task LabelAfterBreak_DoesNotOfferNonEnclosingLabel()
+        => VerifyItemIsAbsentAsync("""
+            class C
+            {
+                void F()
+                {
+                    other: while (true) { }
+
+                    outer: while (true)
+                    {
+                        break $$
+                    }
+                }
+            }
+            """, "other");
+
+    [Fact]
+    public Task LabelAfterBreak_DoesNotOfferPlainLabel()
+        => VerifyItemIsAbsentAsync("""
+            class C
+            {
+                void F()
+                {
+                    plain: ;
+                    outer: while (true)
+                    {
+                        break $$
+                    }
+                }
+            }
+            """, "plain");
+
+    [Fact]
+    public Task LabelAfterBreak_OffersMultipleEnclosingLabels()
+        => VerifyExpectedItemsAsync("""
+            class C
+            {
+                void F()
+                {
+                    outer: while (true)
+                    {
+                        inner: while (true)
+                        {
+                            break $$
+                        }
+                    }
+                }
+            }
+            """, [
+            ItemExpectation.Exists("outer"),
+            ItemExpectation.Exists("inner"),
+        ]);
+
+    [Fact]
+    public Task LabelAfterBreak_ExistingIdentifier()
+        => VerifyItemExistsAsync("""
+            class C
+            {
+                void F()
+                {
+                    outer: while (true)
+                    {
+                        break ou$$
+                    }
+                }
+            }
+            """, "outer");
+
     [Fact, WorkItem("http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542225")]
     public Task AttributeName()
         => VerifyExpectedItemsAsync("""

--- a/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
+++ b/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationServiceRunner.cs
@@ -294,16 +294,42 @@ internal partial class CSharpRecommendationService
                 aliasSymbol.Target));
         }
 
-        private ImmutableArray<ISymbol> GetSymbolsForLabelContext()
+    private ImmutableArray<ISymbol> GetSymbolsForLabelContext()
+    {
+        var allLabels = _context.SemanticModel.LookupLabels(_context.LeftToken.SpanStart);
+
+        var token = _context.LeftToken;
+        if (token.IsKind(SyntaxKind.BreakKeyword) || token.IsKind(SyntaxKind.ContinueKeyword))
         {
-            var allLabels = _context.SemanticModel.LookupLabels(_context.LeftToken.SpanStart);
-
-            // Exclude labels (other than 'default') that come from case switch statements
-
-            return allLabels
-                .WhereAsArray(label => label.DeclaringSyntaxReferences.First().GetSyntax(_cancellationToken)
-                    .Kind() is SyntaxKind.LabeledStatement or SyntaxKind.DefaultSwitchLabel);
+            var position = token.SpanStart;
+            return allLabels.WhereAsArray(
+                static (label, arg) => IsValidBreakOrContinueTargetLabel(label, arg.position, arg.isBreak, arg.cancellationToken),
+                (position, isBreak: token.IsKind(SyntaxKind.BreakKeyword), cancellationToken: _cancellationToken));
         }
+
+        // Exclude labels (other than 'default') that come from case switch statements
+
+        return allLabels
+            .WhereAsArray(label => label.DeclaringSyntaxReferences.First().GetSyntax(_cancellationToken)
+                .Kind() is SyntaxKind.LabeledStatement or SyntaxKind.DefaultSwitchLabel);
+    }
+
+    private static bool IsValidBreakOrContinueTargetLabel(ISymbol label, int position, bool isBreak, CancellationToken cancellationToken)
+    {
+        var declaringSyntax = label.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax(cancellationToken);
+        if (declaringSyntax is not LabeledStatementSyntax labeledStatement)
+            return false;
+
+        if (!labeledStatement.Span.Contains(position))
+            return false;
+
+        var statement = labeledStatement.Statement;
+        if (isBreak && statement is SwitchStatementSyntax)
+            return true;
+
+        return statement is ForStatementSyntax or ForEachStatementSyntax or ForEachVariableStatementSyntax
+            or WhileStatementSyntax or DoStatementSyntax;
+    }
 
         private ImmutableArray<ISymbol> GetSymbolsForTypeOrNamespaceContext()
         {

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -2137,7 +2137,8 @@ internal static partial class SyntaxTreeExtensions
 
     public static bool IsLabelContext(this SyntaxTree syntaxTree, int position, CancellationToken cancellationToken)
     {
-        var token = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken);
+        var token = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken)
+            .GetPreviousTokenIfTouchingWord(position);
 
         var gotoStatement = token.GetAncestor<GotoStatementSyntax>();
         if (gotoStatement != null)
@@ -2147,15 +2148,19 @@ internal static partial class SyntaxTreeExtensions
                 return true;
             }
 
-            if (gotoStatement.Expression != null &&
-                !gotoStatement.Expression.IsMissing &&
-                gotoStatement.Expression is IdentifierNameSyntax &&
-                ((IdentifierNameSyntax)gotoStatement.Expression).Identifier == token &&
+            if (gotoStatement.Expression is IdentifierNameSyntax { IsMissing: false, Identifier: var identifier } &&
+                identifier == token &&
                 token.IntersectsWith(position))
             {
                 return true;
             }
         }
+
+        if (token.IsKind(SyntaxKind.BreakKeyword) && token.Parent is BreakStatementSyntax)
+            return true;
+
+        if (token.IsKind(SyntaxKind.ContinueKeyword) && token.Parent is ContinueStatementSyntax)
+            return true;
 
         return false;
     }


### PR DESCRIPTION
## Summary
- Extend `IsLabelContext` for break/continue keywords.
- Filter `GetSymbolsForLabelContext` to only offer valid labels (loops for continue, loops+switches for break).
- 11 completion tests.

> Stack: **3/8** — Completion