### PR TITLE
7/8: Add Quick Info (hover) tests for labeled break/continue

### DIFF
--- a/src/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
@@ -619,7 +619,7 @@ class C
         await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, CapabilitiesWithVSExtensions);
         var results = await RunGetHoverAsync(testLspServer, testLspServer.GetLocations("caret").Single());
         Assert.NotNull(results);
-        VerifyVSContent(results, "label outer");
+        VerifyVSContent(results, $"({FeaturesResources.label}) outer");
     }
 
     [Theory, CombinatorialData]
@@ -644,7 +644,7 @@ class C
         await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, CapabilitiesWithVSExtensions);
         var results = await RunGetHoverAsync(testLspServer, testLspServer.GetLocations("caret").Single());
         Assert.NotNull(results);
-        VerifyVSContent(results, "label outer");
+        VerifyVSContent(results, $"({FeaturesResources.label}) outer");
     }
 
     private static async Task<LSP.Hover> RunGetHoverAsync(

--- a/src/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
+++ b/src/LanguageServer/ProtocolUnitTests/Hover/HoverTests.cs
@@ -600,6 +600,53 @@ class C
             """, results.Contents.Fourth.Value);
     }
 
+    [Theory, CombinatorialData]
+    public async Task TestGetHoverAsync_LabeledBreak(bool mutatingLspWorkspace)
+    {
+        var markup =
+            """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        break {|caret:outer|};
+                    }
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, CapabilitiesWithVSExtensions);
+        var results = await RunGetHoverAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+        Assert.NotNull(results);
+        VerifyVSContent(results, "label outer");
+    }
+
+    [Theory, CombinatorialData]
+    public async Task TestGetHoverAsync_LabeledContinue(bool mutatingLspWorkspace)
+    {
+        var markup =
+            """
+            class C
+            {
+                void M()
+                {
+                    outer: for (int i = 0; i < 10; i++)
+                    {
+                        while (true)
+                        {
+                            continue {|caret:outer|};
+                        }
+                    }
+                }
+            }
+            """;
+        await using var testLspServer = await CreateTestLspServerAsync(markup, mutatingLspWorkspace, CapabilitiesWithVSExtensions);
+        var results = await RunGetHoverAsync(testLspServer, testLspServer.GetLocations("caret").Single());
+        Assert.NotNull(results);
+        VerifyVSContent(results, "label outer");
+    }
+
     private static async Task<LSP.Hover> RunGetHoverAsync(
         TestLspServer testLspServer,
         LSP.Location caret,


### PR DESCRIPTION
## Summary
- Verify hover on label in `break outer;`/`continue outer;` shows `(label) outer` tooltip.
- Uses `FeaturesResources.label` for localized assertion.
- No production code changes.

> Stack: **7/8** — Quick Info