### PR TITLE
[labeled break/continue] Resolve label even when the target loop/switch is missing (experimental)

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2507,7 +2507,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return this.BindExpression(node, diagnostics, SyntaxFacts.IsInvoked(node), SyntaxFacts.IsIndexed(node));
         }
 
-        public BoundExpression BindLabel(ExpressionSyntax node, BindingDiagnosticBag diagnostics)
+        public BoundExpression BindLabel(ExpressionSyntax node, BindingDiagnosticBag diagnostics, bool reportErrors = true)
         {
             var name = node as IdentifierNameSyntax;
             if (name == null)
@@ -2524,7 +2524,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!result.IsMultiViable)
             {
-                Error(diagnostics, ErrorCode.ERR_LabelNotFound, node, labelName);
+                if (reportErrors)
+                {
+                    Error(diagnostics, ErrorCode.ERR_LabelNotFound, node, labelName);
+                }
                 result.Free();
                 return BadExpression(node, result.Kind);
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2965,18 +2965,37 @@ namespace Microsoft.CodeAnalysis.CSharp
                 MessageID.IDS_FeatureLabeledBreakContinue.CheckFeatureAvailability(diagnostics, node, name.GetLocation());
             }
 
-            var target = isBreak ? this.GetBreakLabel(labelName) : this.GetContinueLabel(labelName);
+            // Suppress label-not-found errors here; if the lookup fails we'll instead report the
+            // more specific ERR_NoBreakId/ERR_NoContinueId/ERR_NoBreakOrCont below.  We still want
+            // to perform the lookup so we have a BoundLabel for the SemanticModel and so that
+            // ControlFlowPass marks the label as referenced (suppressing WRN_UnreferencedLabel).
+            var label = name == null ? null : BindLabel(name, diagnostics, reportErrors: false) as BoundLabel;
+
+            LabelSymbol? target = isBreak ? this.GetBreakLabel(labelName) : this.GetContinueLabel(labelName);
+            var hasErrors = false;
             if (target == null)
             {
                 Error(diagnostics,
                     labelName != null ? (isBreak ? ErrorCode.ERR_NoBreakId : ErrorCode.ERR_NoContinueId) : ErrorCode.ERR_NoBreakOrCont,
                     name ?? (SyntaxNode)node,
                     labelName == null ? [] : [labelName]);
-                return new BoundBadStatement(node, childBoundNodes: [], hasErrors: true);
+
+                if (label == null)
+                    return new BoundBadStatement(node, childBoundNodes: [], hasErrors: true);
+
+                // We resolved the identifier to *some* label symbol but it isn't on an enclosing
+                // loop/switch.  Use that as the target so we still produce a normal
+                // BoundBreakStatement/BoundContinueStatement: the SemanticModel can then resolve
+                // the identifier, and downstream passes treat the label as referenced (suppressing
+                // WRN_UnreferencedLabel on the otherwise-unused label).  The node is still flagged
+                // as having errors via the diagnostic reported above.
+                target = label.Label;
+                hasErrors = true;
             }
 
-            var label = name == null ? null : BindLabel(name, diagnostics) as BoundLabel;
-            return isBreak ? new BoundBreakStatement(node, target, label) : new BoundContinueStatement(node, target, label);
+            return isBreak
+                ? new BoundBreakStatement(node, target, label, hasErrors)
+                : new BoundContinueStatement(node, target, label, hasErrors);
         }
 #nullable disable
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/ControlFlowPass.cs
@@ -223,6 +223,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case BoundKind.ContinueStatement:
                         {
                             var leave = pending.Branch;
+                            // If the break/continue is already in error, an error has already been
+                            // reported at bind time (e.g. ERR_NoBreakId/ERR_NoContinueId for a
+                            // labeled break/continue with no enclosing target).  Don't pile on with
+                            // a misleading "control cannot leave a delegate" message here.
+                            if (leave.HasErrors)
+                            {
+                                break;
+                            }
+
                             var loc = new SourceLocation(leave.Syntax.GetFirstToken());
                             Diagnostics.Add(ErrorCode.ERR_BadDelegateLeave, loc);
                             break;

--- a/src/Compilers/CSharp/Test/CSharp15/LabeledBreakContinueBindingTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/LabeledBreakContinueBindingTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
@@ -284,9 +286,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             // (5,9): warning CS0164: This label has not been referenced
             //         a: b: c: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "a").WithLocation(5, 9),
-            // (5,12): warning CS0164: This label has not been referenced
-            //         a: b: c: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "b").WithLocation(5, 12),
             // (5,15): warning CS0164: This label has not been referenced
             //         a: b: c: while (true)
             Diagnostic(ErrorCode.WRN_UnreferencedLabel, "c").WithLocation(5, 15),
@@ -770,9 +769,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         L: { break L; }
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
             // (5,20): error CS9379: No enclosing loop or switch statement with the label 'L' out of which to break
             //         L: { break L; }
             Diagnostic(ErrorCode.ERR_NoBreakId, "L").WithArguments("L").WithLocation(5, 20));
@@ -792,9 +788,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         L: if (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
             // (6,19): error CS9379: No enclosing loop or switch statement with the label 'L' out of which to break
             //             break L;
             Diagnostic(ErrorCode.ERR_NoBreakId, "L").WithArguments("L").WithLocation(6, 19));
@@ -814,9 +807,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         L: ;
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
             // (6,28): error CS9379: No enclosing loop or switch statement with the label 'L' out of which to break
             //         while (true) break L;
             Diagnostic(ErrorCode.ERR_NoBreakId, "L").WithArguments("L").WithLocation(6, 28));
@@ -836,9 +826,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         L: System.Console.WriteLine();
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
             // (6,25): error CS9379: No enclosing loop or switch statement with the label 'L' out of which to break
             //         if (true) break L;
             Diagnostic(ErrorCode.ERR_NoBreakId, "L").WithArguments("L").WithLocation(6, 25));
@@ -858,9 +845,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         L: var y = x switch { _ => 1 };
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
             // (6,28): error CS9379: No enclosing loop or switch statement with the label 'L' out of which to break
             //         while (true) break L;
             Diagnostic(ErrorCode.ERR_NoBreakId, "L").WithArguments("L").WithLocation(6, 28));
@@ -879,9 +863,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         L: lock (o) { break L; }
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 9),
             // (5,29): error CS9379: No enclosing loop or switch statement with the label 'L' out of which to break
             //         L: lock (o) { break L; }
             Diagnostic(ErrorCode.ERR_NoBreakId, "L").WithArguments("L").WithLocation(5, 29));
@@ -907,13 +888,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: switch (x)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
-            // (7,13): error CS8070: Control cannot fall out of switch from final case label ('default:')
-            //             default: continue outer;
-            Diagnostic(ErrorCode.ERR_SwitchFallOut, "default:").WithArguments("default:").WithLocation(7, 13),
-            // (7,31): error CS9379: No enclosing loop with the label 'outer' out of which to continue
+            // (7,31): error CS9380: No enclosing loop with the label 'outer' out of which to continue
             //             default: continue outer;
             Diagnostic(ErrorCode.ERR_NoContinueId, "outer").WithArguments("outer").WithLocation(7, 31));
     }
@@ -936,9 +911,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: while (false) { }
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
             // (6,30): error CS9379: No enclosing loop or switch statement with the label 'outer' out of which to break
             //         while (true) { break outer; }
             Diagnostic(ErrorCode.ERR_NoBreakId, "outer").WithArguments("outer").WithLocation(6, 30));
@@ -958,15 +930,9 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (5,33): error CS9379: No enclosing loop with the label 'outer' out of which to continue
+            // (5,33): error CS9380: No enclosing loop with the label 'outer' out of which to continue
             //         while (true) { continue outer; }
-            Diagnostic(ErrorCode.ERR_NoContinueId, "outer").WithArguments("outer").WithLocation(5, 33),
-            // (6,9): warning CS0162: Unreachable code detected
-            //         outer: while (false) { }
-            Diagnostic(ErrorCode.WRN_UnreachableCode, "outer").WithLocation(6, 9),
-            // (6,9): warning CS0164: This label has not been referenced
-            //         outer: while (false) { }
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(6, 9));
+            Diagnostic(ErrorCode.ERR_NoContinueId, "outer").WithArguments("outer").WithLocation(5, 33));
     }
 
     [Fact]
@@ -988,10 +954,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
         CreateCompilation(source).VerifyDiagnostics(
             // (7,19): error CS9379: No enclosing loop or switch statement with the label 'outer' out of which to break
             //             break outer;
-            Diagnostic(ErrorCode.ERR_NoBreakId, "outer").WithArguments("outer").WithLocation(7, 19),
-            // (8,9): warning CS0164: This label has not been referenced
-            //         outer: foreach (var y in new int[0]) { }
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(8, 9));
+            Diagnostic(ErrorCode.ERR_NoBreakId, "outer").WithArguments("outer").WithLocation(7, 19));
     }
 
     [Fact]
@@ -1011,12 +974,9 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (7,22): error CS9379: No enclosing loop with the label 'outer' out of which to continue
+            // (7,22): error CS9380: No enclosing loop with the label 'outer' out of which to continue
             //             continue outer;
-            Diagnostic(ErrorCode.ERR_NoContinueId, "outer").WithArguments("outer").WithLocation(7, 22),
-            // (8,9): warning CS0164: This label has not been referenced
-            //         outer: foreach (var y in new int[0]) { }
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(8, 9));
+            Diagnostic(ErrorCode.ERR_NoContinueId, "outer").WithArguments("outer").WithLocation(7, 22));
     }
 
     [Fact]
@@ -1065,12 +1025,9 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (7,22): error CS9379: No enclosing loop with the label 'outer' out of which to continue
+            // (7,22): error CS9380: No enclosing loop with the label 'outer' out of which to continue
             //             continue outer;
-            Diagnostic(ErrorCode.ERR_NoContinueId, "outer").WithArguments("outer").WithLocation(7, 22),
-            // (9,9): warning CS0164: This label has not been referenced
-            //         outer: ;
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(9, 9));
+            Diagnostic(ErrorCode.ERR_NoContinueId, "outer").WithArguments("outer").WithLocation(7, 22));
     }
 
     [Fact]
@@ -1090,10 +1047,7 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: ;
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
-            // (8,22): error CS9379: No enclosing loop with the label 'outer' out of which to continue
+            // (8,22): error CS9380: No enclosing loop with the label 'outer' out of which to continue
             //             continue outer;
             Diagnostic(ErrorCode.ERR_NoContinueId, "outer").WithArguments("outer").WithLocation(8, 22));
     }
@@ -1169,9 +1123,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             }
             """;
         CreateCompilation(source).VerifyDiagnostics(
-            // (5,9): warning CS0164: This label has not been referenced
-            //         outer: while (true)
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(5, 9),
             // (7,30): error CS9379: No enclosing loop or switch statement with the label 'outer' out of which to break
             //             void F() { break outer; }
             Diagnostic(ErrorCode.ERR_NoBreakId, "outer").WithArguments("outer").WithLocation(7, 30));
@@ -2056,9 +2007,6 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             break L;
             """;
         CreateCompilation(source, options: TestOptions.ReleaseExe).VerifyDiagnostics(
-            // (1,1): warning CS0164: This label has not been referenced
-            // L: ;
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(1, 1),
             // (2,7): error CS9379: No enclosing loop or switch statement with the label 'L' out of which to break
             // break L;
             Diagnostic(ErrorCode.ERR_NoBreakId, "L").WithArguments("L").WithLocation(2, 7));
@@ -2331,6 +2279,245 @@ public sealed class LabeledBreakContinueBindingTests : CSharpTestBase
             // (1,21): warning CS9113: Parameter 'p2' is unread.
             // class C(int p1, int p2)
             Diagnostic(ErrorCode.WRN_UnreadPrimaryConstructorParameter, "p2").WithArguments("p2").WithLocation(1, 21));
+    }
+
+    #endregion
+
+    #region Resolved-label-as-target side effects (probing for leaks)
+
+    // When a labeled break/continue can't find an enclosing loop/switch, but the identifier does
+    // resolve to *some* label symbol, the binder uses that label as the target so that downstream
+    // passes treat the label as referenced.  These tests probe whether using a reachable-but-illegal
+    // label as the target leaks any unexpected diagnostics in interesting scopes (lambdas, async
+    // lambdas, iterator methods, finally blocks, separate switch sections, etc.).
+
+    [Fact]
+    public void Break_InsideLambda_LabelOutside_LeaksBadDelegateLeave()
+    {
+        // Pre-existing behavior, NOT introduced by the resolved-label-as-target change: the lambda
+        // binder lets GetBreakLabel walk past the lambda boundary at bind time and find the outer
+        // loop's break label.  As a result BindBreakOrContinue produces a non-errored
+        // BoundBreakStatement and ControlFlowPass later reports CS1632 ("Control cannot leave...")
+        // when the break can't actually be matched to a loop in the lambda's local scope.
+        // Documented here so we notice if the resolved-label-as-target change ever starts
+        // surfacing a *different* leak in this scenario.
+        var source = """
+            using System;
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        Action a = () => { break outer; };
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (6,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(6, 9),
+            // (8,32): error CS1632: Control cannot leave the body of an anonymous method or lambda expression
+            //             Action a = () => { break outer; };
+            Diagnostic(ErrorCode.ERR_BadDelegateLeave, "break").WithLocation(8, 32));
+    }
+
+    [Fact]
+    public void Continue_InsideAsyncLambda_LabelOutside_LeaksBadDelegateLeave()
+    {
+        // Same lambda-boundary behavior as above, this time for an async lambda + continue.
+        var source = """
+            using System;
+            using System.Threading.Tasks;
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        Func<Task> a = async () => { await Task.Yield(); continue outer; };
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (7,9): warning CS0164: This label has not been referenced
+            //         outer: while (true)
+            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "outer").WithLocation(7, 9),
+            // (9,62): error CS1632: Control cannot leave the body of an anonymous method or lambda expression
+            //             Func<Task> a = async () => { await Task.Yield(); continue outer; };
+            Diagnostic(ErrorCode.ERR_BadDelegateLeave, "continue").WithLocation(9, 62));
+    }
+
+    [Fact]
+    public void Break_InsideIterator_LabelOutside_StillReportsUnreachableCode()
+    {
+        // Inside an iterator method with a labeled break that has no valid target.  The break
+        // becomes errored -> WRN_UnreferencedLabel is suppressed for `outer:`.  CS0162 is still
+        // reported on the trailing `while (true)` because the previous `while (true)` body is
+        // unreachable for a different reason (the break above has nothing to do with it).
+        // Probing test: confirms the resolved-label-as-target change does not introduce
+        // a *new* unreachable-code surprise here.
+        var source = """
+            using System.Collections.Generic;
+            class C
+            {
+                IEnumerable<int> M()
+                {
+                    outer: while (true)
+                    {
+                        yield return 1;
+                    }
+                    while (true) break outer;
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (10,9): warning CS0162: Unreachable code detected
+            //         while (true) break outer;
+            Diagnostic(ErrorCode.WRN_UnreachableCode, "while").WithLocation(10, 9),
+            // (10,28): error CS9379: No enclosing loop or switch statement with the label 'outer' out of which to break
+            //         while (true) break outer;
+            Diagnostic(ErrorCode.ERR_NoBreakId, "outer").WithArguments("outer").WithLocation(10, 28));
+    }
+
+    [Fact]
+    public void Break_InsideFinally_LabelOnOuterBlock_LeaksControlCannotLeaveFinally()
+    {
+        // The user-declared label `L:` *is* visible from inside the finally block, so BindLabel
+        // resolves it.  GetBreakLabel returns null (try/finally provide no break target) so
+        // BindBreakOrContinue falls through with target := L's LabelSymbol and hasErrors=true.
+        // ControlFlowPass then reports CS0157 ("Control cannot leave the body of a finally
+        // clause"), because the synthesized goto edge would in fact leave the finally.
+        // This is a real *new* leak introduced by the resolved-label-as-target change.
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    L: try { }
+                    finally
+                    {
+                        break L;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (8,13): error CS0157: Control cannot leave the body of a finally clause
+            //             break L;
+            Diagnostic(ErrorCode.ERR_BadFinallyLeave, "break").WithLocation(8, 13),
+            // (8,19): error CS9379: No enclosing loop or switch statement with the label 'L' out of which to break
+            //             break L;
+            Diagnostic(ErrorCode.ERR_NoBreakId, "L").WithArguments("L").WithLocation(8, 19));
+    }
+
+    [Fact]
+    public void Break_InSwitchSection_LabelInDifferentSection_LabelTreatedAsReferenced()
+    {
+        // The label `L:` is in a different switch section from `break L;`.  Labels are visible
+        // across switch sections at bind time, so BindLabel resolves to L's LabelSymbol and the
+        // synthesized target makes flow analysis treat L as referenced (no CS0164).
+        var source = """
+            class C
+            {
+                void M(int x)
+                {
+                    switch (x)
+                    {
+                        case 0:
+                            L: break;
+                        case 1:
+                            break L;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (10,23): error CS9379: No enclosing loop or switch statement with the label 'L' out of which to break
+            //             break L;
+            Diagnostic(ErrorCode.ERR_NoBreakId, "L").WithArguments("L").WithLocation(10, 23));
+    }
+
+    [Fact]
+    public void Continue_TargetOnSwitch_SuppressesSwitchFallOutAndUnreferencedLabel()
+    {
+        // Documents that ERR_SwitchFallOut (CS8070) is also suppressed for the case where the
+        // synthesized target makes the continue look like a real exit edge.  This is a
+        // *consequence* of resolving the bad label as the target, not a separately reported error.
+        var source = """
+            class C
+            {
+                void M(int x)
+                {
+                    outer: switch (x)
+                    {
+                        default: continue outer;
+                    }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (7,31): error CS9380: No enclosing loop with the label 'outer' out of which to continue
+            //             default: continue outer;
+            Diagnostic(ErrorCode.ERR_NoContinueId, "outer").WithArguments("outer").WithLocation(7, 31));
+    }
+
+    [Fact]
+    public void Break_LabelOnFollowingLoop_SuppressesUnreachableCodeAndUnreferencedLabel()
+    {
+        // Documents that WRN_UnreachableCode (CS0162) is also suppressed.  The break is errored,
+        // but flow analysis still treats it as a real exit, so the trailing labeled loop
+        // becomes "reachable" via the synthesized target -- no unreachable warning is produced.
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    while (true) { break outer; }
+                    outer: while (false) { }
+                }
+            }
+            """;
+        CreateCompilation(source).VerifyDiagnostics(
+            // (5,30): error CS9379: No enclosing loop or switch statement with the label 'outer' out of which to break
+            //         while (true) { break outer; }
+            Diagnostic(ErrorCode.ERR_NoBreakId, "outer").WithArguments("outer").WithLocation(5, 30));
+    }
+
+    [Fact]
+    public void GetSymbolInfo_BreakWithBadTarget_SemanticModelStillResolvesIdentifier()
+    {
+        // The IDE side-benefit of this approach: even though the break is errored, the SemanticModel
+        // can still resolve the identifier to its label symbol, so find-references / rename / etc.
+        // continue to work on the broken code.
+        var source = """
+            class C
+            {
+                void M()
+                {
+                    outer: while (true)
+                    {
+                        void F() { break outer; }
+                        F();
+                    }
+                }
+            }
+            """;
+        var comp = CreateCompilation(source);
+        comp.VerifyDiagnostics(
+            // (7,30): error CS9379: No enclosing loop or switch statement with the label 'outer' out of which to break
+            //             void F() { break outer; }
+            Diagnostic(ErrorCode.ERR_NoBreakId, "outer").WithArguments("outer").WithLocation(7, 30));
+
+        var tree = comp.SyntaxTrees.Single();
+        var model = comp.GetSemanticModel(tree);
+        var labelDecl = tree.GetRoot().DescendantNodes().OfType<LabeledStatementSyntax>().Single();
+        var declaredSymbol = model.GetDeclaredSymbol(labelDecl);
+
+        var breakSyntax = tree.GetRoot().DescendantNodes().OfType<BreakStatementSyntax>().Single(b => b.Name is not null);
+        Assert.Same(declaredSymbol, model.GetSymbolInfo(breakSyntax.Name!).Symbol);
     }
 
     #endregion

--- a/src/Compilers/CSharp/Test/CSharp15/LabeledBreakContinueIOperationTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/LabeledBreakContinueIOperationTests.cs
@@ -1279,10 +1279,7 @@ public sealed class LabeledBreakContinueIOperationTests : SemanticModelTestBase
         comp.VerifyDiagnostics(
             // (5,45): error CS9379: No enclosing loop or switch statement with the label 'L' out of which to break
             //         /*<bind>*/L: { while (true) { break L; } }/*</bind>*/
-            Diagnostic(ErrorCode.ERR_NoBreakId, "L").WithArguments("L").WithLocation(5, 45),
-            // (5,19): warning CS0164: This label has not been referenced
-            //         /*<bind>*/L: { while (true) { break L; } }/*</bind>*/
-            Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 19));
+            Diagnostic(ErrorCode.ERR_NoBreakId, "L").WithArguments("L").WithLocation(5, 45));
 
         var tree = comp.SyntaxTrees.Single();
         var model = comp.GetSemanticModel(tree);
@@ -1291,7 +1288,7 @@ public sealed class LabeledBreakContinueIOperationTests : SemanticModelTestBase
         var op = model.GetOperation(breakSyntax);
 
         Assert.NotNull(op);
-        Assert.Equal(OperationKind.Invalid, op!.Kind);
+        Assert.Equal(OperationKind.Branch, op!.Kind);
 
         VerifyOperationTreeAndDiagnosticsForTest<LabeledStatementSyntax>(source, """
             ILabeledOperation (Label: L) (OperationKind.Labeled, Type: null, IsInvalid) (Syntax: 'L: { while  ... reak L; } }')
@@ -1302,8 +1299,7 @@ public sealed class LabeledBreakContinueIOperationTests : SemanticModelTestBase
                       ILiteralOperation (OperationKind.Literal, Type: System.Boolean, Constant: True) (Syntax: 'true')
                     Body:
                       IBlockOperation (1 statements) (OperationKind.Block, Type: null, IsInvalid) (Syntax: '{ break L; }')
-                        IInvalidOperation (OperationKind.Invalid, Type: null, IsInvalid) (Syntax: 'break L;')
-                          Children(0)
+                        IBranchOperation (BranchKind.Break, Label: L) (OperationKind.Branch, Type: null, IsInvalid) (Syntax: 'break L;')
                     IgnoredCondition:
                       null
             """, new[]
@@ -1311,9 +1307,6 @@ public sealed class LabeledBreakContinueIOperationTests : SemanticModelTestBase
                 // (5,45): error CS9379: No enclosing loop or switch statement with the label 'L' out of which to break
                 //         /*<bind>*/L: { while (true) { break L; } }/*</bind>*/
                 Diagnostic(ErrorCode.ERR_NoBreakId, "L").WithArguments("L").WithLocation(5, 45),
-                // (5,19): warning CS0164: This label has not been referenced
-                //         /*<bind>*/L: { while (true) { break L; } }/*</bind>*/
-                Diagnostic(ErrorCode.WRN_UnreferencedLabel, "L").WithLocation(5, 19),
             });
     }
 

--- a/src/Compilers/CSharp/Test/CSharp15/LabeledBreakContinueSemanticModelTests.cs
+++ b/src/Compilers/CSharp/Test/CSharp15/LabeledBreakContinueSemanticModelTests.cs
@@ -131,8 +131,11 @@ public sealed class LabeledBreakContinueSemanticModelTests : CSharpTestBase
     }
 
     [Fact]
-    public void GetSymbolInfo_InvalidBreak_DoesNotResolveToLabelSymbol()
+    public void GetSymbolInfo_InvalidBreak_StillResolvesToLabelSymbol()
     {
+        // Even though the break has no enclosing loop/switch with a matching label, the identifier
+        // still resolves to the (out-of-scope) label symbol so that IDE features (find-refs,
+        // rename, etc.) work on the broken code.
         var source = """
             class C
             {
@@ -161,12 +164,15 @@ public sealed class LabeledBreakContinueSemanticModelTests : CSharpTestBase
         Assert.NotNull(labelRef);
 
         var symbolInfo = model.GetSymbolInfo(labelRef);
-        Assert.Null(symbolInfo.Symbol);
+        Assert.Same(declaredSymbol, symbolInfo.Symbol);
     }
 
     [Fact]
-    public void GetSymbolInfo_InvalidContinue_DoesNotResolveToLabelSymbol()
+    public void GetSymbolInfo_InvalidContinue_StillResolvesToLabelSymbol()
     {
+        // Even though the continue has no enclosing loop with a matching label, the identifier
+        // still resolves to the (out-of-scope) label symbol so that IDE features (find-refs,
+        // rename, etc.) work on the broken code.
         var source = """
             class C
             {
@@ -195,7 +201,7 @@ public sealed class LabeledBreakContinueSemanticModelTests : CSharpTestBase
         Assert.NotNull(labelRef);
 
         var symbolInfo = model.GetSymbolInfo(labelRef);
-        Assert.Null(symbolInfo.Symbol);
+        Assert.Same(declaredSymbol, symbolInfo.Symbol);
     }
 
     #endregion


### PR DESCRIPTION
Championed issue: https://github.com/dotnet/csharplang/issues/9875
Speclet: https://github.com/dotnet/csharplang/blob/main/proposals/labeled-break-continue.md#detailed-design
Test plan: dotnet/roslyn#83209

## Summary

Experimental follow-up on top of dotnet/roslyn#83198.  When a labeled `break`/`continue` can't find an enclosing loop/switch with the requested label, but the identifier *does* resolve to some label symbol in source, the binder uses that label as the target of a normal `BoundBreakStatement` / `BoundContinueStatement` (with `hasErrors: true`) instead of producing an empty `BoundBadStatement`.

Goals:

- Suppress the spurious `WRN_UnreferencedLabel` (CS0164) on labels that the user clearly *did* reference, even if illegally.
- Have `SemanticModel.GetSymbolInfo` resolve the identifier to its label symbol so that IDE features (find-references, rename, document highlights, navigation, ...) continue to work on broken code.
- Produce an `IBranchOperation` (with `IsInvalid`) instead of an opaque `IInvalidOperation`.

Implementation:

- `Binder_Statements.BindBreakOrContinue`: bind the label via `BindLabel` first; if `target == null` but `label != null`, set `target = label.Label` and `hasErrors = true`, then fall through to the normal break/continue construction.
- `Binder_Expressions.BindLabel`: gains an optional `reportErrors` (default true) parameter so we can request the resolution without piling on a redundant `ERR_LabelNotFound` (CS0159).
- `ControlFlowPass.RemoveReturns`: suppresses the `ERR_BadDelegateLeave` (CS1632) leak for already-errored break/continue, since the bind-time error has already explained the real problem.

Probing tests are added under a new `Resolved-label-as-target side effects (probing for leaks)` region to document scenarios where the change interacts with other diagnostics (lambda boundary, async lambda, iterator method, finally block, switch sections, label-on-following-loop, label-on-switch). These document both the wins (no `WRN_UnreferencedLabel`) and the consequences:

- A `break` inside a `finally` referencing a visible outer label still produces `ERR_BadFinallyLeave` in addition to `ERR_NoBreakId`, because the synthesized goto-edge would in fact leave the finally.
- `ERR_BadDelegateLeave` (CS1632) is still reported for `break`/`continue` inside lambdas because the lambda binder permits cross-boundary lookup at bind time even though the operation is illegal.  This is *pre-existing* behavior and is tested here so we notice if the change starts producing a *different* leak.
- `ERR_SwitchFallOut` (CS8070) and `WRN_UnreachableCode` (CS0162) are no longer reported in scenarios where the synthesized target makes flow analysis treat the labeled break/continue as a real exit edge.

The 19 existing tests that previously asserted `WRN_UnreferencedLabel`/secondary diagnostics on these scenarios are updated to reflect the new behavior, and two `GetSymbolInfo_Invalid{Break,Continue}_DoesNotResolveToLabelSymbol` tests are renamed/flipped to `_StillResolvesToLabelSymbol`.

This PR is intentionally separated so it can be evaluated independently of the rest of the labeled break/continue stack and either merged or dropped without affecting dotnet/roslyn#83197-dotnet/roslyn#83204.

---

Stacked:

1. dotnet/roslyn#83197
2. dotnet/roslyn#83198
3. **(this PR)**
4. dotnet/roslyn#83199
5. dotnet/roslyn#83200
6. dotnet/roslyn#83201
7. dotnet/roslyn#83202
8. dotnet/roslyn#83203
9. dotnet/roslyn#83204
10. dotnet/roslyn#83499